### PR TITLE
Store user ID into model upon model creation

### DIFF
--- a/app/StarModel.php
+++ b/app/StarModel.php
@@ -10,5 +10,17 @@ use Jenssegers\Mongodb\Eloquent\Model as Eloquent;
  */
 class StarModel extends Eloquent
 {
-
+    /**
+     * Store user ID into model upon model creation
+     */
+    public static function boot()
+    {
+        parent::boot();
+        if (!\Auth::guest()) {
+            static::creating(function ($model) {
+                $userId = \Auth::user()->id;
+                $model->ownerID = $userId;
+            });
+        }
+    }
 }


### PR DESCRIPTION
Make sure each created resource (document) references owner

Store `ownerId` - ID of user that created the object.

It's set from `StarModel` so all models extend it.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58601d6c3e5bbe4cb74ea61f/tasks/5863dc293e5bbe1e74462405)

## Checklist
- [x] Tests covered

## Test notes

Tests covered, upon new user registration StarModel ignores saving ownerId. Upon creation of model, ownerId is stored into model. Upon updating model nothing changes on ownerId field.