### PR TITLE
Cron that moves unfinished tasks from sprint to following sprint on sprint end date

### DIFF
--- a/app/Console/Commands/UnfinishedTasks.php
+++ b/app/Console/Commands/UnfinishedTasks.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\GenericModel;
+
+class UnfinishedTasks extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'unfinished:tasks:auto-move';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Cron that moves unfinished tasks from sprint to following sprint on sprint end date.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        //get all projects
+        GenericModel::setCollection('projects');
+        $projects = GenericModel::all();
+
+        //get all admin users
+        GenericModel::setCollection('profiles');
+        $admins = GenericModel::where('admin', '=', true)->get();
+
+        $activeProjects = [];
+        $sprints = [];
+
+        // Get all active projects and sprints
+        GenericModel::setCollection('sprints');
+        foreach ($projects as $project) {
+            if (!empty($project->acceptedBy) && $project->isComplete !== true && !empty($project->sprints)) {
+                $activeProjects[$project->id] = $project;
+                foreach ($project->sprints as $sprintId) {
+                    $sprints[$sprintId] = GenericModel::where('_id', '=', $sprintId)->first();
+                }
+            }
+        }
+
+        $sprintEndedTasks = [];
+        $endedSprints = [];
+        $futureSprints = [];
+        $futureSprintsStartDates = [];
+
+        $date = new \DateTime();
+        $unixNow = $date->format('U');
+        $checkDay = date('Y-m-d', $unixNow);
+        $unixDayAgo = $unixNow - 24 * 60 * 60;
+        $checkDayAgo = date('Y-m-d', $unixDayAgo);
+
+        GenericModel::setCollection('tasks');
+        foreach ($sprints as $sprint) {
+            $sprintStartDueDate = date('Y-m-d', $sprint->start);
+            $sprintEndDueDate = date('Y-m-d', $sprint->end);
+            if ($sprintEndDueDate === $checkDayAgo && !empty($sprint->tasks)) {
+                foreach ($sprint->tasks as $taskId) {
+                    $task = GenericModel::where('_id', '=', $taskId)->first();
+                    if (empty($task->owner)) {
+                        $sprintEndedTasks[$taskId] = $task;
+                        $endedSprints[$sprint->project_id] = $sprint;
+                    }
+                }
+            } elseif ($unixNow < $sprint->start || $checkDay === $sprintStartDueDate) {
+                $futureSprints[] = $sprint;
+                $futureSprintsStartDates[$sprint->project_id][] = $sprint->start;
+            }
+        }
+
+        if (!empty($sprintEndedTasks)) {
+            //ping on slack admins if there are no future sprints created so we can move unfinished tasks from sprint to
+            //following sprint on sprint end date
+            if (empty($futureSprints)) {
+                foreach ($admins as $admin) {
+                    if ($admin->slack) {
+                        $recipient = '@' . $admin->slack;
+                        $message = 'Hey! There are no future sprints created to move unfinished tasks from ended ' .
+                            'sprints!';
+                        \SlackChat::message($recipient, $message);
+                    }
+                }
+            } else {
+                foreach ($futureSprints as $sprint) {
+                    if ($sprint->start === min($futureSprintsStartDates[$sprint->project_id])) {
+                        foreach ($sprintEndedTasks as $task) {
+                            if ($task->project_id === $sprint->project_id) {
+                                $task->sprint_id = $sprint->_id;
+                                $task->save();
+
+                                $newSprintTasks = $sprint->tasks;
+                                $newSprintTasks[] = $task->_id;
+                                $sprint->tasks = $newSprintTasks;
+                                $sprint->save();
+
+                                $oldSprintTaskUpdate = array_values(array_diff($endedSprints[$sprint->project_id]->
+                                tasks, [$task->_id]));
+                                $oldSprint = $endedSprints[$sprint->project_id];
+                                $oldSprint->tasks = $oldSprintTaskUpdate;
+                                $oldSprint->save();
+                                $this->info('Task' . $task->title . 'moved to sprint ' . $sprint->title);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -14,7 +14,8 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         Commands\SprintReminder::class,
-        Commands\XpDeduction::class
+        Commands\XpDeduction::class,
+        Commands\UnfinishedTasks::class
     ];
 
     /**
@@ -29,5 +30,7 @@ class Kernel extends ConsoleKernel
                   ->twiceDaily(8, 14);
          $schedule->command('xp:activity:auto-deduct')
                   ->dailyAt('13:00');
+         $schedule->command('unfinished:tasks:auto-move')
+                  ->dailyAt('00:01');
     }
 }


### PR DESCRIPTION
Cron that moves unfinished tasks from sprint to following sprint on sprint end date

Check if there are some unfinished tasks upon sprint end due date and move them to following sprint if exists. If not ping admins on slack.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58657e043e5bbe64a471c546/tasks/58764b633e5bbe555d05a53e)

## Checklist

- [x] Tests covered

## Test notes

Create 2 projects for example. On each project create few sprints. For example. create one that due date ended 10 days ago, one that due date ended day before today, and few of them that start date is today, or in the future. On each sprint create tasks without owner, and tasks with owner. When cron starts results should be as expected. If there is sprint that ended day before cron starts it removes all tasks without owner (unfinished) and move them to next sprint that starts first in the future. Tasks are moved as expected for each project and sprints. Database records are set as expected, removed from old sprint->tasks array and set to new one, also each task record sprint->id is changed as it should be. Also try to create sprint that ended day before today and without future sprints, cron will ping all admins on slack to notify that there are no sprints so tasks cannot be moved. 

