### PR TITLE
Refactor event listener to accept any generic model

### DIFF
--- a/app/Events/GenericModelCreate.php
+++ b/app/Events/GenericModelCreate.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Events\Event;
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+
+class GenericModelCreate extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Events/GenericModelUpdate.php
+++ b/app/Events/GenericModelUpdate.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Events\Event;
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+
+class GenericModelUpdate extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
-use App\Events\TaskUpdateSlackNotify;
+use App\Events\GenericModelCreate;
+use App\Events\GenericModelUpdate;
 use App\GenericModel;
 use Illuminate\Http\Request;
-use App\Events\ModelUpdate;
 use App\Events\TaskUpdate;
 use MongoDB\BSON\ObjectID;
 
@@ -115,9 +115,7 @@ class GenericResourceController extends Controller
 
         $model = GenericModel::create($fields);
 
-        if ($model->getCollection() === 'tasks' && $request->has('owner') && !empty($request->input('owner'))) {
-            event(new TaskUpdateSlackNotify($model), []);
-        }
+        event(new GenericModelCreate($model));
 
         if ($model->save()) {
             return $this->jsonSuccess($model);
@@ -145,14 +143,7 @@ class GenericResourceController extends Controller
 
         $model->fill($updateFields);
 
-        if ($model->getCollection() === 'tasks' && $model->isDirty()) {
-            event(new TaskUpdateSlackNotify($model));
-        }
-
-
-        if ($model->passed_qa === true) {
-            event(new ModelUpdate($model));
-        }
+        event(new GenericModelUpdate($model));
 
         if ($model->save()) {
             return $this->jsonSuccess($model);

--- a/app/Listeners/GenericModelCreate.php
+++ b/app/Listeners/GenericModelCreate.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Listeners;
+
+use App\GenericModel;
+use Illuminate\Support\Facades\App;
+
+class GenericModelCreate
+{
+    /**
+     * GenericModelCreate constructor.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event
+     * @param \App\Events\GenericModelCreate $event
+     */
+    public function handle(\App\Events\GenericModelCreate $event)
+    {
+        $app = App::getFacadeRoot();
+        $dispatcher = $app->events;
+
+        $presetCollection = GenericModel::getCollection();
+        GenericModel::setCollection('listenerRules');
+        $listenerRules = GenericModel::all();
+
+        $eventsListeners = [];
+
+        foreach ($listenerRules as $rule) {
+            if (!empty($rule->resource) && $rule->resource === $presetCollection && !empty($rule->event) &&
+                $rule->event === 'create'
+            ) {
+                foreach ($rule->listeners as $events => $listeners) {
+                    $eventsListeners[$events] = $listeners;
+                }
+            }
+        }
+
+        if (!empty($eventsListeners)) {
+            foreach ($eventsListeners as $eventName => $listeners) {
+                foreach ($eventsListeners[$eventName] as $listener) {
+                    $dispatcher->listen($eventName, $listener);
+                    event(new $eventName($event->model));
+                }
+            }
+        }
+
+        GenericModel::setCollection($presetCollection);
+    }
+}

--- a/app/Listeners/GenericModelCreate.php
+++ b/app/Listeners/GenericModelCreate.php
@@ -8,14 +8,6 @@ use Illuminate\Support\Facades\App;
 class GenericModelCreate
 {
     /**
-     * GenericModelCreate constructor.
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * Handle the event
      * @param \App\Events\GenericModelCreate $event
      */

--- a/app/Listeners/GenericModelCreate.php
+++ b/app/Listeners/GenericModelCreate.php
@@ -2,9 +2,6 @@
 
 namespace App\Listeners;
 
-use App\GenericModel;
-use Illuminate\Support\Facades\App;
-
 class GenericModelCreate
 {
     /**
@@ -13,34 +10,7 @@ class GenericModelCreate
      */
     public function handle(\App\Events\GenericModelCreate $event)
     {
-        $app = App::getFacadeRoot();
-        $dispatcher = $app->events;
-
-        $presetCollection = GenericModel::getCollection();
-        GenericModel::setCollection('listenerRules');
-        $listenerRules = GenericModel::all();
-
-        $eventsListeners = [];
-
-        foreach ($listenerRules as $rule) {
-            if (!empty($rule->resource) && $rule->resource === $presetCollection && !empty($rule->event) &&
-                $rule->event === 'create'
-            ) {
-                foreach ($rule->listeners as $events => $listeners) {
-                    $eventsListeners[$events] = $listeners;
-                }
-            }
-        }
-
-        if (!empty($eventsListeners)) {
-            foreach ($eventsListeners as $eventName => $listeners) {
-                foreach ($eventsListeners[$eventName] as $listener) {
-                    $dispatcher->listen($eventName, $listener);
-                    event(new $eventName($event->model));
-                }
-            }
-        }
-
-        GenericModel::setCollection($presetCollection);
+        $action = 'create';
+        $this->triggerListeners($event, $action);
     }
 }

--- a/app/Listeners/GenericModelUpdate.php
+++ b/app/Listeners/GenericModelUpdate.php
@@ -8,15 +8,6 @@ use Illuminate\Support\Facades\App;
 class GenericModelUpdate
 {
     /**
-     *
-     * GenericModelUpdate constructor.
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * Handle the event.
      * @param \App\Events\GenericModelUpdate $event
      */

--- a/app/Listeners/GenericModelUpdate.php
+++ b/app/Listeners/GenericModelUpdate.php
@@ -2,45 +2,18 @@
 
 namespace App\Listeners;
 
-use App\GenericModel;
-use Illuminate\Support\Facades\App;
+use App\Traits\DynamicListener;
 
 class GenericModelUpdate
 {
+    use DynamicListener;
     /**
      * Handle the event.
      * @param \App\Events\GenericModelUpdate $event
      */
     public function handle(\App\Events\GenericModelUpdate $event)
     {
-        $app = App::getFacadeRoot();
-        $dispatcher = $app->events;
-
-        $presetCollection = GenericModel::getCollection();
-        GenericModel::setCollection('listenerRules');
-        $listenerRules = GenericModel::all();
-
-        $eventsListeners = [];
-
-        foreach ($listenerRules as $rule) {
-            if (!empty($rule->resource) && $rule->resource === $presetCollection && !empty($rule->event) &&
-                $rule->event === 'update'
-            ) {
-                foreach ($rule->listeners as $events => $listeners) {
-                    $eventsListeners[$events] = $listeners;
-                }
-            }
-        }
-
-        if (!empty($eventsListeners)) {
-            foreach ($eventsListeners as $eventName => $listeners) {
-                foreach ($eventsListeners[$eventName] as $listener) {
-                    $dispatcher->listen($eventName, $listener);
-                    event(new $eventName($event->model));
-                }
-            }
-        }
-
-        GenericModel::setCollection($presetCollection);
+        $action = 'update';
+        $this->triggerListeners($event, $action);
     }
 }

--- a/app/Listeners/GenericModelUpdate.php
+++ b/app/Listeners/GenericModelUpdate.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Listeners;
+
+use App\GenericModel;
+use Illuminate\Support\Facades\App;
+
+class GenericModelUpdate
+{
+    /**
+     *
+     * GenericModelUpdate constructor.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     * @param \App\Events\GenericModelUpdate $event
+     */
+    public function handle(\App\Events\GenericModelUpdate $event)
+    {
+        $app = App::getFacadeRoot();
+        $dispatcher = $app->events;
+
+        $presetCollection = GenericModel::getCollection();
+        GenericModel::setCollection('listenerRules');
+        $listenerRules = GenericModel::all();
+
+        $eventsListeners = [];
+
+        foreach ($listenerRules as $rule) {
+            if (!empty($rule->resource) && $rule->resource === $presetCollection && !empty($rule->event) &&
+                $rule->event === 'update'
+            ) {
+                foreach ($rule->listeners as $events => $listeners) {
+                    $eventsListeners[$events] = $listeners;
+                }
+            }
+        }
+
+        if (!empty($eventsListeners)) {
+            foreach ($eventsListeners as $eventName => $listeners) {
+                foreach ($eventsListeners[$eventName] as $listener) {
+                    $dispatcher->listen($eventName, $listener);
+                    event(new $eventName($event->model));
+                }
+            }
+        }
+
+        GenericModel::setCollection($presetCollection);
+    }
+}

--- a/app/Listeners/ProfileUpdate.php
+++ b/app/Listeners/ProfileUpdate.php
@@ -8,14 +8,6 @@ use App\Helpers\MailSend;
 class ProfileUpdate
 {
     /**
-     * ProfileUpdate constructor.
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
      * @param \App\Events\ProfileUpdate $event
      */
     public function handle(\App\Events\ProfileUpdate $event)

--- a/app/Providers/TheShopEventServiceProvider.php
+++ b/app/Providers/TheShopEventServiceProvider.php
@@ -19,6 +19,9 @@ class TheShopEventServiceProvider extends ServiceProvider
         'App\Events\GenericModelUpdate' => [
             'App\Listeners\GenericModelUpdate'
         ],
+        'App\Events\ProfileUpdate' => [
+            'App\Listeners\ProfileUpdate'
+        ],
     ];
 
     /**

--- a/app/Providers/TheShopEventServiceProvider.php
+++ b/app/Providers/TheShopEventServiceProvider.php
@@ -5,7 +5,7 @@ namespace App\Providers;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
-class EventServiceProvider extends ServiceProvider
+class TheShopEventServiceProvider extends ServiceProvider
 {
     /**
      * The event listener mappings for the application.
@@ -13,15 +13,12 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        'App\Events\TaskUpdateSlackNotify' => [
-            'App\Listeners\TaskUpdateSlackNotification',
+        'App\Events\GenericModelCreate' => [
+            'App\Listeners\GenericModelCreate'
         ],
-        'App\Events\ProfileUpdate' => [
-            'App\Listeners\ProfileUpdate'
+        'App\Events\GenericModelUpdate' => [
+            'App\Listeners\GenericModelUpdate'
         ],
-        'App\Events\ModelUpdate' => [
-            'App\Listeners\TaskUpdateXP',
-        ]
     ];
 
     /**

--- a/app/Traits/DynamicListener.php
+++ b/app/Traits/DynamicListener.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Traits;
+
+use App\GenericModel;
+use Illuminate\Support\Facades\App;
+
+trait DynamicListener
+{
+    public function triggerListeners($event, $action)
+    {
+        $app = App::getFacadeRoot();
+        $dispatcher = $app->events;
+
+        $presetCollection = GenericModel::getCollection();
+        GenericModel::setCollection('listener-rules');
+        $listenerRules = GenericModel::all();
+
+        $eventsListeners = [];
+
+        foreach ($listenerRules as $rule) {
+            if (!empty($rule->resource) && $rule->resource === $presetCollection && !empty($rule->event) &&
+                $rule->event === $action
+            ) {
+                foreach ($rule->listeners as $events => $listeners) {
+                    $eventsListeners[$events] = $listeners;
+                }
+            }
+        }
+
+        foreach ($eventsListeners as $eventName => $listenersArray) {
+            foreach ($listenersArray as $listener) {
+                $dispatcher->listen($eventName, $listener);
+                event(new $eventName($event->model));
+            }
+        }
+
+        GenericModel::setCollection($presetCollection);
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -155,7 +155,7 @@ return [
          */
         App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
-        App\Providers\EventServiceProvider::class,
+        App\Providers\TheShopEventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
     ],
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -16,6 +16,7 @@ namespace
         {
             $this->call(AclCollectionSeeder::class);
             $this->call(ValidationsSeeder::class);
+            $this->call(ListenerRulesSeeder::class);
         }
     }
 }

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -13,8 +13,8 @@ namespace {
          */
         public function run()
         {
-            DB::collection('listenerRules')->delete();
-            DB::collection('listenerRules')->insert(
+            DB::collection('listener-rules')->delete();
+            DB::collection('listener-rules')->insert(
                 [
                     [
                         'resource' => 'tasks',

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace {
+
+    use Illuminate\Database\Seeder;
+
+    class ListenerRulesSeeder extends Seeder
+    {
+        /**
+         * Run the database seeds.
+         *
+         * @return void
+         */
+        public function run()
+        {
+            DB::collection('listenerRules')->delete();
+            DB::collection('listenerRules')->insert(
+                [
+                    [
+                        'resource' => 'tasks',
+                        'event' => 'create',
+                        'listeners' => []
+                    ],
+                    [
+                        'resource' => 'tasks',
+                        'event' => 'update',
+                        'listeners' => [
+                            'App\Events\TaskUpdateSlackNotify' => [
+                                'App\Listeners\TaskUpdateSlackNotification',
+                            ],
+                            'App\Events\ModelUpdate' => [
+                                'App\Listeners\TaskUpdateXP',
+                            ]
+                        ]
+                    ],
+                ]
+            );
+        }
+    }
+}


### PR DESCRIPTION
Refactor event listener to accept any generic model

All listener rules should be saved to `listener-rules` collection, should contain map from collection name to list of real listeners and then trigger them dynamically.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58657e043e5bbe64a471c546/tasks/5876615b3e5bbe6b007f1609)

## Checklist

- [x] Seeders written
- [x] Tests covered

## Test notes

Tested on task update, events and listeners registred in listenerRules collection triggered, tested task create - for purpose of testing copied App\Events\TaskUpdateSlackNotify into "create" listeners collection and his listener, everything worked as expected. 