### PR TITLE
Expanded to move all tasks that are not marked as QA passed

### DIFF
--- a/app/Console/Commands/UnfinishedTasks.php
+++ b/app/Console/Commands/UnfinishedTasks.php
@@ -78,7 +78,7 @@ class UnfinishedTasks extends Command
             if ($sprintEndDueDate === $checkDayAgo && !empty($sprint->tasks)) {
                 foreach ($sprint->tasks as $taskId) {
                     $task = GenericModel::where('_id', '=', $taskId)->first();
-                    if (empty($task->owner)) {
+                    if ($task->passed_qa !== true) {
                         $sprintEndedTasks[$taskId] = $task;
                         $endedSprints[$sprint->project_id] = $sprint;
                     }
@@ -119,7 +119,7 @@ class UnfinishedTasks extends Command
                                 $oldSprint = $endedSprints[$sprint->project_id];
                                 $oldSprint->tasks = $oldSprintTaskUpdate;
                                 $oldSprint->save();
-                                $this->info('Task' . $task->title . 'moved to sprint ' . $sprint->title);
+                                $this->info('Task ' . $task->title . ' moved to sprint ' . $sprint->title);
                             }
                         }
                     }


### PR DESCRIPTION
Expand cron that moves tasks to next sprint

Move unfinished tasks to next sprint as well (all that are not marked as QA passed)

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/587a90c63e5bbe555d05a748)

## Checklist
- [ ] Tests covered

## Test notes

Created new project with few sprints. Created few tasks with flag passed_qa and without flag passed_qa. The one that end due date was day before cron started, all tasks without flag passed_qa moved to following sprint.