### PR TITLE
Added price field to sprints validation seeder, field must be numeric

### DIFF
--- a/database/seeds/ValidationsSeeder.php
+++ b/database/seeds/ValidationsSeeder.php
@@ -120,6 +120,7 @@ namespace {
                         ],
                     [
                         'fields' => [
+                            'price' => 'numeric'
                         ],
                         'resource' => 'sprints',
                         'acl' => [


### PR DESCRIPTION
Add `price` field to sprints validation seeder

make sure validation is set for field to be numeric

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/587b7ae63e5bbe0e3b4d5f52)

## Checklist
- [x] Seeders written

Seeder ValidationsSeeder expanded with field 'price' => 'numeric under 'resource' => 'sprints' 