### PR TITLE
Migration to update existing tasks priority, configuration return taskPriorities

### DIFF
--- a/config/sharedSettings.php
+++ b/config/sharedSettings.php
@@ -41,22 +41,27 @@ return [
             'Node',
             'Planning'
         ],
-        'webDomain' => env('WEB_DOMAIN', 'http://the-shop.io:3000/')
+        'webDomain' => env('WEB_DOMAIN', 'http://the-shop.io:3000/'),
+        'taskPriorities' => [
+            'High',
+            'Medium',
+            'Low'
+        ]
     ],
 
     /**
      * Dynamic configuration that depends on external services
      */
     'externalConfiguration' => [
-        'slack' => [
-            [
-                'resolver' => [
-                    'class' => \Vluzrmos\SlackApi\Facades\SlackTeam::class,
-                    'method' => 'info'
-                ],
-                'settingName' => 'teamInfo'
-            ]
-        ],
+    'slack' => [
+        [
+            'resolver' => [
+                'class' => \Vluzrmos\SlackApi\Facades\SlackTeam::class,
+                'method' => 'info'
+            ],
+            'settingName' => 'teamInfo'
+        ]
+    ],
     ]
 
 ];

--- a/database/migrations/2017_01_16_092942_add_tasks_priority.php
+++ b/database/migrations/2017_01_16_092942_add_tasks_priority.php
@@ -17,26 +17,16 @@ namespace {
             GenericModel::setCollection('tasks');
             $tasks = GenericModel::all();
             foreach ($tasks as $task) {
-                $task->update([
-                    'priority' => 'Medium'
-                ]);
+                if (empty($task->priority)) {
+                    $task->update([
+                        'priority' => 'Medium'
+                    ]);
+                }
             }
         }
-
-        /**
-         * Reverse the migrations.
-         *
-         * @return void
-         */
+        
         public function down()
         {
-            GenericModel::setCollection('tasks');
-            $tasks = GenericModel::all();
-            foreach ($tasks as $task) {
-                $task->update([
-                    'priority' => ''
-                ]);
-            }
         }
     }
 }

--- a/database/migrations/2017_01_16_092942_add_tasks_priority.php
+++ b/database/migrations/2017_01_16_092942_add_tasks_priority.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace {
+
+    use Illuminate\Database\Migrations\Migration;
+    use App\GenericModel;
+
+    class AddTasksPriority extends Migration
+    {
+        /**
+         * Run the migrations.
+         *
+         * @return void
+         */
+        public function up()
+        {
+            GenericModel::setCollection('tasks');
+            $tasks = GenericModel::all();
+            foreach ($tasks as $task) {
+                $task->update([
+                    'priority' => 'Medium'
+                ]);
+            }
+        }
+
+        /**
+         * Reverse the migrations.
+         *
+         * @return void
+         */
+        public function down()
+        {
+            GenericModel::setCollection('tasks');
+            $tasks = GenericModel::all();
+            foreach ($tasks as $task) {
+                $task->update([
+                    'priority' => ''
+                ]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Configuration API to return `taskPriorities`

Write migration for existing tasks and set priority to medium

Return following
`High`
`Medium`
`Low`

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/587a94543e5bbe6ef2219527)

## Checklist
- [x] Migrations written
- [x] Tests covered

## Test notes

Configuration API returns taskPriorities as requested. Migration loop through existing tasks and sets up 'priority' => 'Medium'. Migration roll back updates all existing tasks and set priority empty.
