### PR TITLE
Feature/listener generic model history

### DIFF
--- a/app/Events/GenericModelHistory.php
+++ b/app/Events/GenericModelHistory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Events;
+
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+
+class GenericModelHistory extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Listeners/GenericModelHistory.php
+++ b/app/Listeners/GenericModelHistory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\App;
+
+class GenericModelHistory
+{
+    /**
+     * Handle the event.
+     *
+     * @param  GenericModelHistory  $event
+     * @return void
+     */
+    public function handle(\App\Events\GenericModelHistory $event)
+    {
+        //
+    }
+}

--- a/app/Listeners/GenericModelHistory.php
+++ b/app/Listeners/GenericModelHistory.php
@@ -24,7 +24,7 @@ class GenericModelHistory
                         'oldValue' => $oldValues[$newField],
                         'newValue' => $newValue
                     ];
-                } elseif (!key_exists($newField, $oldValues)) {
+                } else {
                     $history[] = [
                         'profileId' => \Auth::user()->id,
                         'fieldName' => $newField,

--- a/app/Listeners/GenericModelHistory.php
+++ b/app/Listeners/GenericModelHistory.php
@@ -2,20 +2,31 @@
 
 namespace App\Listeners;
 
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Support\Facades\App;
-
 class GenericModelHistory
 {
     /**
      * Handle the event.
-     *
-     * @param  GenericModelHistory  $event
-     * @return void
+     * @param \App\Events\GenericModelHistory $event
      */
     public function handle(\App\Events\GenericModelHistory $event)
     {
-        //
+        if ($event->model->isDirty()) {
+            $newValues = $event->model->getDirty();
+            $oldValues = $event->model->getOriginal();
+
+            foreach ($oldValues as $oldField => $oldValue) {
+                if (key_exists($oldField, $newValues)) {
+                    $history = $event->model->history;
+                    $history[] = [
+                        'profileId' => \Auth::user()->id,
+                        'filedName' => $oldField,
+                        'oldValue' => $oldValue,
+                        'newValue' => $newValues[$oldField]
+                    ];
+                    $event->model->history = $history;
+                    $event->model->save();
+                }
+            }
+        }
     }
 }

--- a/app/Providers/TheShopEventServiceProvider.php
+++ b/app/Providers/TheShopEventServiceProvider.php
@@ -22,6 +22,9 @@ class TheShopEventServiceProvider extends ServiceProvider
         'App\Events\ProfileUpdate' => [
             'App\Listeners\ProfileUpdate'
         ],
+        'App\Events\GenericModelHistory' => [
+            'App\Listeners\GenericModelHistory'
+        ],
     ];
 
     /**

--- a/app/Providers/TheShopEventServiceProvider.php
+++ b/app/Providers/TheShopEventServiceProvider.php
@@ -21,10 +21,7 @@ class TheShopEventServiceProvider extends ServiceProvider
         ],
         'App\Events\ProfileUpdate' => [
             'App\Listeners\ProfileUpdate'
-        ],
-        'App\Events\GenericModelHistory' => [
-            'App\Listeners\GenericModelHistory'
-        ],
+        ]
     ];
 
     /**

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -30,6 +30,9 @@ namespace {
                             ],
                             'App\Events\ModelUpdate' => [
                                 'App\Listeners\TaskUpdateXP',
+                            ],
+                            'App\Events\GenericModelHistory' => [
+                                'App\Listeners\GenericModelHistory'
                             ]
                         ]
                     ],


### PR DESCRIPTION
Event observer to write history of generic model field changes on StarAPI

`history` field that will store following:
`profileId`
`fieldName`
`oldValue`
`newValue`

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/587649f13e5bbe624e71c042)

## Checklist
- [x] Tests covered

## Test notes

Created few tasks, on task update listener creates history field with all changed fields with requested structure. Changed task few times and it adds new history records as expected. Updated ListenerRulesSeeder so listener will trigger when task is updated.

## Screenshots

![image](https://cloud.githubusercontent.com/assets/19432548/21982126/22ef9d00-dbeb-11e6-8d0f-14593834d5d0.png)
