### PR TITLE
Feature/set user role upon registration

### DIFF
--- a/app/Profile.php
+++ b/app/Profile.php
@@ -34,6 +34,7 @@ class Profile extends StarModel implements AuthenticatableContract, CanResetPass
         'active',
         'xp_id',
         'admin',
+        'role'
     ];
 
     /**
@@ -57,6 +58,7 @@ class Profile extends StarModel implements AuthenticatableContract, CanResetPass
         $model = new static($attributes);
 
         $model->xp = 50;
+        $model->role = 'standard';
 
         $model->save();
 

--- a/database/migrations/2017_01_16_144358_update_profile_role.php
+++ b/database/migrations/2017_01_16_144358_update_profile_role.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace {
+
+    use Illuminate\Database\Migrations\Migration;
+    use App\GenericModel;
+
+    class UpdateProfileRole extends Migration
+    {
+        /**
+         * Run the migrations.
+         *
+         * @return void
+         */
+        public function up()
+        {
+            GenericModel::setCollection('profiles');
+            $profiles = GenericModel::all();
+            foreach ($profiles as $profile) {
+                if (empty($profile->role) && $profile->admin === true) {
+                    $profile->update([
+                        'role' => 'admin'
+                    ]);
+                } elseif (empty($profile->role) && $profile->employee === true) {
+                    $profile->update([
+                        'role' => 'employee'
+                    ]);
+                } elseif (empty($profile->role)) {
+                    $profile->update([
+                        'role' => 'standard'
+                    ]);
+                }
+            }
+        }
+
+        public function down()
+        {
+        }
+    }
+}

--- a/database/migrations/2017_01_16_144358_update_profile_role.php
+++ b/database/migrations/2017_01_16_144358_update_profile_role.php
@@ -21,11 +21,15 @@ namespace {
                     $profile->update([
                         'role' => 'admin'
                     ]);
-                } elseif (empty($profile->role) && $profile->employee === true) {
+                }
+
+                if (empty($profile->role) && $profile->employee === true) {
                     $profile->update([
                         'role' => 'employee'
                     ]);
-                } elseif (empty($profile->role)) {
+                }
+
+                if (empty($profile->role)) {
                     $profile->update([
                         'role' => 'standard'
                     ]);


### PR DESCRIPTION
Make sure that `role` field is saved on profile registration as `standard`

Also write migration that will go through existing profile records and set it to standard, if `employee` is true, set it to `employee`, and if `admin` is true set the `role` to `admin`

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/587a96003e5bbe6ef2219531)

## Checklist
- [x] Migrations written
- [x] Tests covered

## Test notes

Upon new user registration filed 'role' is created with value 'standard'. Tested migration, everything working as expected and described in task description.