### PR TITLE
Configuration API to return userRoles, UserRolesSeeder written also

### DIFF
--- a/app/Resolvers/UserRoles.php
+++ b/app/Resolvers/UserRoles.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Resolvers;
+
+use App\GenericModel;
+
+class UserRoles
+{
+    public static function getRoles()
+    {
+        $preSetCollection = GenericModel::getCollection();
+        GenericModel::setCollection('user-roles');
+        $userRoles = GenericModel::first();
+
+        $resolvedRoles = array_map('strtolower', $userRoles->userRoles);
+
+        GenericModel::setCollection($preSetCollection);
+
+        return $resolvedRoles;
+    }
+}

--- a/config/sharedSettings.php
+++ b/config/sharedSettings.php
@@ -61,6 +61,21 @@ return [
     ],
 
     /**
+     * Dynamic internal configuration
+     */
+    'internalDynamicConfiguration' => [
+        'userRoles' => [
+            [
+                'resolver' => [
+                    'class' => \App\Resolvers\UserRoles::class,
+                    'method' => 'getRoles'
+                ],
+                'settingName' => 'userRoles'
+            ]
+        ],
+    ],
+
+    /**
      * Dynamic configuration that depends on external services
      */
     'externalConfiguration' => [

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -18,6 +18,7 @@ namespace
             $this->call(ValidationsSeeder::class);
             $this->call(ListenerRulesSeeder::class);
             $this->call(AdapterRulesSeeder::class);
+            $this->call(UserRolesSeeder::class);
         }
     }
 }

--- a/database/seeds/UserRolesSeeder.php
+++ b/database/seeds/UserRolesSeeder.php
@@ -1,0 +1,30 @@
+<?php
+namespace {
+
+    use Illuminate\Database\Seeder;
+
+    class UserRolesSeeder extends Seeder
+    {
+        /**
+         * Run the database seeds.
+         *
+         * @return void
+         */
+        public function run()
+        {
+            DB::collection('user-roles')->delete();
+            DB::collection('user-roles')->insert(
+                [
+                    [
+                        'userRoles' => [
+                            'Standard',
+                            'Client',
+                            'Employee',
+                            'Admin'
+                        ]
+                    ]
+                ]
+            );
+        }
+    }
+}


### PR DESCRIPTION
Configuration API endpoint to return list of user roles

Add new section under `internal` section to behave as `externalConfiguration` section (use `resolver` logic as well). Put that under `dynamic` section of internal configuration, but flatten the output for it so that API doesn't resolve values as nested, but instead in same level as rest of `internal` section.

Roles should be (also seeded): 
`Standard`
`Client`
`Employee`
`Admin`

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/587a93bf3e5bbe6b007f17f7)

## Checklist
- [x] Seeders written
- [x] Tests covered

## Test notes

API configuration returns result as expected. Dynamic internal config resolved in same level as rest of 'internal' configuration.