### PR TITLE
Listener for user task claim, UserInputException, ListenerRulesSeeder updated

### DIFF
--- a/app/Events/TaskClaim.php
+++ b/app/Events/TaskClaim.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Events;
+
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+
+class TaskClaim extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Exceptions/UserInputException.php
+++ b/app/Exceptions/UserInputException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Exceptions;
+
+/**
+ * Class UserInputException
+ * @package App\Exceptions
+ */
+class UserInputException extends \Exception
+{
+    /**
+     * UserInputException constructor.
+     * @param string $message
+     * @param \Exception|null $previous
+     */
+    public function __construct($message, \Exception $previous = null)
+    {
+        parent::__construct($message, 400, $previous);
+    }
+}

--- a/app/Listeners/TaskClaim.php
+++ b/app/Listeners/TaskClaim.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Exceptions\UserInputException;
+use App\GenericModel;
+
+class TaskClaim
+{
+    /**
+     * Handle the event.
+     * @param \App\Events\TaskClaim $event
+     * @throws UserInputException
+     */
+    public function handle(\App\Events\TaskClaim $event)
+    {
+        $task = $event->model;
+
+        $previousTasks = [];
+
+        if ($task->isDirty()) {
+            $preSetCollection = GenericModel::getCollection();
+            $updatedFields = $task->getDirty();
+            if ($task['collection'] === 'tasks' && key_exists('owner', $updatedFields)) {
+                GenericModel::setCollection('tasks');
+                $allTasks = GenericModel::where('_id', '!=', $task->_id)->get();
+                foreach ($allTasks as $item) {
+                    if (empty($item->owner) || !empty($item->owner) && $item->owner === $updatedFields['owner'] &&
+                        $item->passed_qa === true || $item->submitted_for_qa === true
+                    ) {
+                        continue;
+                    }
+                    $previousTasks[] = $item;
+                }
+            }
+
+            if (count($previousTasks) > 0) {
+                throw new UserInputException('Permission denied. There are unfinished previous tasks.');
+            }
+
+            GenericModel::setCollection($preSetCollection);
+        }
+    }
+}

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -31,6 +31,9 @@ namespace {
                             'App\Events\ModelUpdate' => [
                                 'App\Listeners\TaskUpdateXP',
                             ],
+                            'App\Events\TaskClaim' => [
+                                'App\Listeners\TaskClaim'
+                            ],
                             'App\Events\GenericModelHistory' => [
                                 'App\Listeners\GenericModelHistory'
                             ]


### PR DESCRIPTION
Event listener for user task claiming

...that will make sure user can claim a task only if he has finished all previous tasks or if his active tasks are submitted for QA, otherwise throws exception

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/587b83223e5bbe0e3b4d5f86)

## Checklist
- [x] Tests covered

## Test notes

Created sprint with 10 tasks. Logged in with test account, claimed one task, tried to claim another one exception throwed. Then submitted_for_qa, claimed another one, submitted_for_qa, claimed another one, throwed exception. Logged in with admin, set up some tasks passed_qa. Logged in with test acc, tried different variations of current tasks (unassigned, assigned not finished, assigned and submitted_for_qa), everything worked as expected. 
Describe briefly how to test the code updates.
