### PR TITLE
Validate all cron jobs

### DIFF
--- a/app/Console/Commands/SprintReminder.php
+++ b/app/Console/Commands/SprintReminder.php
@@ -75,6 +75,7 @@ class SprintReminder extends Command
 
         // Ping on slack all users on active projects about unassigned tasks on active sprints
         $taskCount = [];
+
         foreach ($tasks as $task) {
             if (!key_exists($task->project_id, $taskCount)) {
                 $taskCount[$task->project_id] = 1;
@@ -83,20 +84,25 @@ class SprintReminder extends Command
             }
         }
 
-        foreach ($activeProjects as $project) {
-            foreach ($members as $member) {
-                if (in_array($member->_id, $project->members) && $member->slack) {
-                    $recipient = '@' . $member->slack;
-                    $projectName = $project->name;
-                    $unassignedTasks = $taskCount[$project->_id];
-                    $message = '*Reminder*:'
-                        . 'There are * '
-                        . $unassignedTasks
-                        . '* unassigned tasks on active sprints'
-                        . ', for project *'
-                        . $projectName
-                        . '*)';
-                    \SlackChat::message($recipient, $message);
+        if (!empty($taskCount)) {
+            foreach ($activeProjects as $project) {
+                if (!key_exists($project->_id, $taskCount)) {
+                    continue;
+                }
+                foreach ($members as $member) {
+                    if (in_array($member->_id, $project->members) && $member->slack) {
+                        $recipient = '@' . $member->slack;
+                        $projectName = $project->name;
+                        $unassignedTasks = $taskCount[$project->_id];
+                        $message = '*Reminder*:'
+                            . 'There are * '
+                            . $unassignedTasks
+                            . '* unassigned tasks on active sprints'
+                            . ', for project *'
+                            . $projectName
+                            . '*';
+                        \SlackChat::message($recipient, $message);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Validate all cron jobs are working properly

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/5880718f3e5bbe274c5f13cd)

## Checklist

- [x] Tests covered

## Test notes

**SprintReminder cron** - **bug** was when there are more projects then one and if there are no unassigned tasks in one of projects, cron throwed error undefined index in array of projectId => number of tasks. **Fixed.** **Everything working as expected now.**

**UnfinishedTasks cron - bug** was that cron was checking for the last day if there is sprint ended with unfinished tasks and let's say that there was one sprint. Admins where wrongly reported because if there are more then one project let's say 3 of them and all tasks from all 3 projects where calculated together and then there was checking if (empty($futureSprints) { //msg admins }. So if one of projects didnt have future sprints, and in 2 other there where future sprints to pass tasks, nothing would happen. In these 2, tasks will be moved, and for this 3rd one, admins wont get notification and tasks wouldn't move. Next day on cron check, that endedSprint is 2 days before check (last day) so in the future when sprint is created there is no possibility that he will check that and move tasks. **Fixed. Working as expected now**, and notifiying admins on which project exactly are missing future sprints. Also now cron is checking if ended due date is < then cron start, so if few days passed and admin create then sprint on next cron job it will move all unfinished tasks from all ended sprints. Everything working as expected now.

**XpDeduction cron** - tested cases, if has activity within 3 days, if doesnt have on 4th day deduct -1 xp, if user is banned skip it, if user is inactive (flag) skip it, if user xp-1 = 0 set banned flag if user doesnt have xp_id field create new record in xp collection, add it to user->xp_id. **Everything working as expected.**

**EmailProfilePerformance cron** - tested and it seems that everything is calculated fine and mails are sent to each user + to admins sent mail with all user performances for requested "lastDays". **One thing strange is the line in report about XP changed by -> it's down in screenshot. Think it's error in ProfilePerformance service?**

## Screenshots

![image](https://cloud.githubusercontent.com/assets/19432548/22119917/ae3f280a-de7d-11e6-9c38-a70c347823ea.png)
