### PR TITLE
Listener for setting task status, unclaimed tasks status cannot be modified

### DIFF
--- a/app/Events/TaskSettingStatus.php
+++ b/app/Events/TaskSettingStatus.php
@@ -5,14 +5,14 @@ namespace App\Events;
 use App\GenericModel;
 use Illuminate\Queue\SerializesModels;
 
-class TaskClaim extends Event
+class TaskSettingStatus extends Event
 {
     use SerializesModels;
 
     public $model;
 
     /**
-     * TaskClaim constructor.
+     * TaskSettingStatus constructor.
      * @param GenericModel $model
      */
     public function __construct(GenericModel $model)

--- a/app/Listeners/TaskSettingStatus.php
+++ b/app/Listeners/TaskSettingStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Exceptions\UserInputException;
+
+class TaskSettingStatus
+{
+    /**
+     * Handle the event.
+     * @param \App\Events\TaskSettingStatus $event
+     * @throws UserInputException
+     */
+    public function handle(\App\Events\TaskSettingStatus $event)
+    {
+        $task = $event->model;
+
+        //if task is not claimed by user, deny task setting status to be changed
+        if ($task->isDirty()) {
+            $updatedFields = $task->getDirty();
+            $keysToCheck = ['paused', 'submitted_for_qa', 'passed_qa'];
+            $checked = array_intersect_key($updatedFields, array_flip($keysToCheck));
+            if ($task['collection'] === 'tasks' && empty($task->owner) && count($checked) > 0) {
+                throw new UserInputException('Permission denied. Task is not claimed.');
+            }
+        }
+    }
+}

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -34,6 +34,9 @@ namespace {
                             'App\Events\TaskClaim' => [
                                 'App\Listeners\TaskClaim'
                             ],
+                            'App\Events\TaskSettingStatus' => [
+                                'App\Listeners\TaskSettingStatus'
+                            ],
                             'App\Events\GenericModelHistory' => [
                                 'App\Listeners\GenericModelHistory'
                             ]


### PR DESCRIPTION
Listener to forbid setting task status (qa, pause,...) until it's claimed / assigned

throw exception otherwise

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/587e28493e5bbe03fa575dea)

## Checklist

- [x] Tests covered

## Test notes

Tested all cases (all fields) on assigned and unassigned tasks. Works fine.

