### PR TITLE
Return task color status

### DIFF
--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -32,37 +32,35 @@ class Task implements AdaptersInterface
 
         if (!empty($taskStatus)) {
             $taskEstimatedSeconds = $mappedValues['estimatedHours'] * 60 * 60;
-            $taskDeliveredOnTime = $taskStatus[$this->task->owner]['workSeconds']
-            <= $taskEstimatedSeconds;
+            $taskDeliveredOnTime = $taskStatus[$this->task->owner]['workSeconds'] <= $taskEstimatedSeconds;
 
             // deadline in last 25% of the time of task
             $lastQuarterOfTask = 0.25 * $taskEstimatedSeconds;
 
+            $colorIndicator = '';
             //generate task color status
-            if ($this->task->passed_qa === true && $taskDeliveredOnTime === true) {
-                $this->task->colorIndicator = 'green';
-                return $this->task;
+            if (($taskEstimatedSeconds - $taskStatus[$this->task->owner]['workSeconds']) <= $lastQuarterOfTask) {
+                $colorIndicator = 'orange';
             }
 
-            if ($this->task->submitted_for_qa === true) {
-                $this->task->colorIndicator = 'blue';
-                return $this->task;
+            if ($taskDeliveredOnTime === false) {
+                $colorIndicator = 'red';
             }
 
             if ($this->task->paused === true) {
-                $this->task->colorIndicator = 'yellow';
-                return $this->task;
+                $colorIndicator = 'yellow';
             }
 
-            if (($taskEstimatedSeconds - $taskStatus[$this->task->owner]['workSeconds']) <= $lastQuarterOfTask) {
-                $this->task->colorIndicator = 'orange';
+            if ($this->task->submitted_for_qa === true) {
+                $colorIndicator = 'blue';
             }
 
-            if ($this->task->passed_qa === false && $taskDeliveredOnTime === false) {
-                $this->task->colorIndicator = 'red';
-                return $this->task;
+            if ($this->task->passed_qa === true) {
+                $colorIndicator = 'green';
             }
         }
+
+        $this->task->colorIndicator = $colorIndicator;
 
         return $this->task;
     }

--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -30,6 +30,8 @@ class Task implements AdaptersInterface
 
         $taskStatus = $profilePerformance->perTask($this->task);
 
+        $colorIndicator = '';
+        
         if (!empty($taskStatus)) {
             $taskEstimatedSeconds = $mappedValues['estimatedHours'] * 60 * 60;
             $taskDeliveredOnTime = $taskStatus[$this->task->owner]['workSeconds'] <= $taskEstimatedSeconds;
@@ -37,7 +39,6 @@ class Task implements AdaptersInterface
             // deadline in last 25% of the time of task
             $lastQuarterOfTask = 0.25 * $taskEstimatedSeconds;
 
-            $colorIndicator = '';
             //generate task color status
             if (($taskEstimatedSeconds - $taskStatus[$this->task->owner]['workSeconds']) <= $lastQuarterOfTask) {
                 $colorIndicator = 'orange';

--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -44,11 +44,6 @@ class Task implements AdaptersInterface
                 return $this->task;
             }
 
-            if ($this->task->passed_qa === true && $taskDeliveredOnTime === false) {
-                $this->task->colorIndicator = 'red';
-                return $this->task;
-            }
-
             if ($this->task->submitted_for_qa === true) {
                 $this->task->colorIndicator = 'blue';
                 return $this->task;
@@ -61,6 +56,11 @@ class Task implements AdaptersInterface
 
             if (($taskEstimatedSeconds - $taskStatus[$this->task->owner]['workSeconds']) <= $lastQuarterOfTask) {
                 $this->task->colorIndicator = 'orange';
+            }
+
+            if ($this->task->passed_qa === false && $taskDeliveredOnTime === false) {
+                $this->task->colorIndicator = 'red';
+                return $this->task;
             }
         }
 

--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -28,6 +28,42 @@ class Task implements AdaptersInterface
         $this->task->estimatedHours = sprintf('%.2f', $this->task->estimatedHours);
         $this->task->xp = sprintf('%.2f', $this->task->xp);
 
+        $taskStatus = $profilePerformance->perTask($this->task);
+
+        if (!empty($taskStatus)) {
+            $taskEstimatedSeconds = $mappedValues['estimatedHours'] * 60 * 60;
+            $taskDeliveredOnTime = $taskStatus[$this->task->owner]['workSeconds']
+            <= $taskEstimatedSeconds ? true : false;
+
+            // deadline in last 25% of the time of task
+            $lastQuarterOfTask = (25 / 100) * $taskEstimatedSeconds;
+
+            //generate task color status
+            if ($this->task->passed_qa === true && $taskDeliveredOnTime === true) {
+                $this->task->colorIndicator = 'Green';
+                return $this->task;
+            }
+
+            if ($this->task->passed_qa === true && $taskDeliveredOnTime === false) {
+                $this->task->colorIndicator = 'Red';
+                return $this->task;
+            }
+
+            if ($this->task->submitted_for_qa === true) {
+                $this->task->colorIndicator = 'Blue';
+                return $this->task;
+            }
+
+            if ($this->task->paused === true) {
+                $this->task->colorIndicator = 'Yellow';
+                return $this->task;
+            }
+
+            if (($taskEstimatedSeconds - $taskStatus[$this->task->owner]['workSeconds']) <= $lastQuarterOfTask) {
+                $this->task->colorIndicator = 'Orange';
+            }
+        }
+
         return $this->task;
     }
 }

--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -33,34 +33,34 @@ class Task implements AdaptersInterface
         if (!empty($taskStatus)) {
             $taskEstimatedSeconds = $mappedValues['estimatedHours'] * 60 * 60;
             $taskDeliveredOnTime = $taskStatus[$this->task->owner]['workSeconds']
-            <= $taskEstimatedSeconds ? true : false;
+            <= $taskEstimatedSeconds;
 
             // deadline in last 25% of the time of task
-            $lastQuarterOfTask = (25 / 100) * $taskEstimatedSeconds;
+            $lastQuarterOfTask = 0.25 * $taskEstimatedSeconds;
 
             //generate task color status
             if ($this->task->passed_qa === true && $taskDeliveredOnTime === true) {
-                $this->task->colorIndicator = 'Green';
+                $this->task->colorIndicator = 'green';
                 return $this->task;
             }
 
             if ($this->task->passed_qa === true && $taskDeliveredOnTime === false) {
-                $this->task->colorIndicator = 'Red';
+                $this->task->colorIndicator = 'red';
                 return $this->task;
             }
 
             if ($this->task->submitted_for_qa === true) {
-                $this->task->colorIndicator = 'Blue';
+                $this->task->colorIndicator = 'blue';
                 return $this->task;
             }
 
             if ($this->task->paused === true) {
-                $this->task->colorIndicator = 'Yellow';
+                $this->task->colorIndicator = 'yellow';
                 return $this->task;
             }
 
             if (($taskEstimatedSeconds - $taskStatus[$this->task->owner]['workSeconds']) <= $lastQuarterOfTask) {
-                $this->task->colorIndicator = 'Orange';
+                $this->task->colorIndicator = 'orange';
             }
         }
 


### PR DESCRIPTION
Expand task adapter to return task color status

Orange - deadline in last 25% of the time of task
Red - deadline missed
Green - QA passed
Yellow - paused
Blue - paused / waiting on QA

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/587f98a03e5bbe6e160123c8)

## Test notes

Tested for blue, yellow, and green! Had problem with testing red and orange cause when i set on FE 5minutes task and then try to check orange or red he automatically changes to for ex. 50minutes, or 2 hours 35 minutes... i'm not sure why? Anyway check PR please for code structure and logic and return, of course, if needed for changes...