### PR TITLE
Added timestamp to generic model history update

### DIFF
--- a/app/Listeners/GenericModelHistory.php
+++ b/app/Listeners/GenericModelHistory.php
@@ -16,20 +16,24 @@ class GenericModelHistory
             $oldValues = $event->model->getOriginal();
 
             $history = $event->model->history;
+            $date = new \DateTime();
+            $unixTime = $date->format('U');
             foreach ($newValues as $newField => $newValue) {
                 if (key_exists($newField, $oldValues)) {
                     $history[] = [
                         'profileId' => \Auth::user()->id,
                         'filedName' => $newField,
                         'oldValue' => $oldValues[$newField],
-                        'newValue' => $newValue
+                        'newValue' => $newValue,
+                        'timestamp' => (int) ($unixTime . '000') // Microtime
                     ];
                 } else {
                     $history[] = [
                         'profileId' => \Auth::user()->id,
                         'fieldName' => $newField,
                         'oldValue' => null,
-                        'newValue' => $newValue
+                        'newValue' => $newValue,
+                        'timestamp' => (int) ($unixTime . '000')
                     ];
                 }
             }
@@ -40,7 +44,8 @@ class GenericModelHistory
                         'profileId' => \Auth::user()->id,
                         'fieldName' => $oldFieldName,
                         'oldValue' => $oldFieldValue,
-                        'newValue' => null
+                        'newValue' => null,
+                        'timestamp' => (int) ($unixTime . '000')
                     ];
                 }
             }


### PR DESCRIPTION
Add timestamp field to history records on generic model update

So other than `fieldName`, `newValue`, `oldValue` and `profileId`, there's `timestamp` field

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5881d3aa3e5bbe274c5f1553/tasks/58837f0c3e5bbe759d57c58c)

## Test notes

Returning as expected `fieldName`, `newValue`, `oldValue` and `profileId`, there's `timestamp`

## Screenshots

![image](https://cloud.githubusercontent.com/assets/19432548/22185580/c594b2f0-e0e8-11e6-9fb0-eca41099894d.png)
