### PR TITLE
Listener to notify admins on slack if task is wrapped up in less than 60% of estimated time

### DIFF
--- a/app/Events/TaskFinishedEarly.php
+++ b/app/Events/TaskFinishedEarly.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Events;
+
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+
+class TaskFinishedEarly extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * TaskFinishedEarly constructor.
+     * @param GenericModel $model
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Listeners/TaskFinishedEarly.php
+++ b/app/Listeners/TaskFinishedEarly.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Listeners;
+
+use App\GenericModel;
+use App\Services\ProfilePerformance;
+use App\Profile;
+use App\Helpers\InputHandler;
+use Illuminate\Support\Facades\Config;
+
+class TaskFinishedEarly
+{
+    /**
+     * Handle the event
+     * @param \App\Events\TaskFinishedEarly $event
+     */
+    public function handle(\App\Events\TaskFinishedEarly $event)
+    {
+        $task = $event->model;
+
+        if ($task->isDirty()) {
+            $updatedFields = $task->getDirty();
+
+            if ($task['collection'] === 'tasks' && key_exists('passed_qa', $updatedFields)) {
+                $profilePerformance = new ProfilePerformance();
+                $preSetCollection = GenericModel::getCollection();
+                GenericModel::setCollection('tasks');
+                $taskPerformance = $profilePerformance->perTask($task);
+                foreach ($taskPerformance as $profileId => $taskDetails) {
+                    $taskOwnerProfile = Profile::find($profileId);
+                    $mappedValues = $profilePerformance->getTaskValuesForProfile($taskOwnerProfile, $task);
+
+                    //calculate estimated time, working time, and 60% of estimated
+                    $estimatedSeconds = max(InputHandler::getInteger($mappedValues['estimatedHours']) * 60 * 60, 1);
+                    $secondsWorking = $taskDetails['workSeconds'];
+                    $sixtyPercentOfEstimate = 0.6 * $estimatedSeconds;
+
+                    //if tasked finished in less than 60% of time send slack notification to admins
+                    if ($secondsWorking <= $sixtyPercentOfEstimate) {
+                        $admins = Profile::where('admin', '=', true)->get();
+                        foreach ($admins as $admin) {
+                            $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
+                            $recipient = '@' . $admin->slack;
+                            $message = 'Hey, task *'
+                                . $task->title
+                                . '* wrapped up in less than *60%* of estimated time. '
+                                . $webDomain
+                                . 'projects/'
+                                . $task->project_id
+                                . '/sprints/'
+                                . $task->sprint_id
+                                . '/tasks/'
+                                . $task->_id;
+                            \SlackChat::message($recipient, $message);
+                        }
+                    }
+                }
+                GenericModel::setCollection($preSetCollection);
+            }
+        }
+    }
+}

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -37,6 +37,9 @@ namespace {
                             'App\Events\TaskSettingStatus' => [
                                 'App\Listeners\TaskSettingStatus'
                             ],
+                            'App\Events\TaskFinishedEarly' => [
+                                'App\Listeners\TaskFinishedEarly'
+                            ],
                             'App\Events\GenericModelHistory' => [
                                 'App\Listeners\GenericModelHistory'
                             ]


### PR DESCRIPTION
Alert admin on slack if task wrapped up in less than 60% of time (event listener)

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5881d3aa3e5bbe274c5f1553/tasks/587b8a193e5bbe6b007f18d1)

## Checklist
- [x] Tests covered

## Test notes

Tested if task wrapped up less then 60% sends slack notification to all admins, if not nothing happens.