### PR TITLE
API to generate task_history for status changes on task model

### DIFF
--- a/app/Events/TaskStatusHistory.php
+++ b/app/Events/TaskStatusHistory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Events\Event;
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class TaskStatusHistory extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * TaskStatusHistory constructor.
+     * @param GenericModel $model
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Listeners/GenericModelHistory.php
+++ b/app/Listeners/GenericModelHistory.php
@@ -51,7 +51,7 @@ class GenericModelHistory
             }
 
             $event->model->history = $history;
-            $event->model->save();
+            //$event->model->save();
         }
     }
 }

--- a/app/Listeners/GenericModelHistory.php
+++ b/app/Listeners/GenericModelHistory.php
@@ -51,7 +51,6 @@ class GenericModelHistory
             }
 
             $event->model->history = $history;
-            //$event->model->save();
         }
     }
 }

--- a/app/Listeners/TaskStatusHistory.php
+++ b/app/Listeners/TaskStatusHistory.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Support\Facades\Config;
+use App\Profile;
+
+class TaskStatusHistory
+{
+
+    /**
+     * Handle the event.
+     * @param \App\Events\TaskStatusHistory $event
+     */
+    public function handle(\App\Events\TaskStatusHistory $event)
+    {
+        $task = $event->model;
+
+        if ($task['collection'] === 'tasks' && $task->isDirty()) {
+            $newValues = $event->model->getDirty();
+            $taskHistory = $event->model->task_history;
+            $taskHistoryStatuses = Config::get('sharedSettings.internalConfiguration.taskHistoryStatuses');
+            $date = new \DateTime();
+            $unixTime = $date->format('U');
+            $taskOwner = Profile::find($task->owner);
+
+            //update task_history if task is claimed or assigned
+            if (key_exists('owner', $newValues)) {
+                $taskOwner = Profile::find($newValues['owner']);
+                $taskHistory[] = [
+                    'user' => $taskOwner->_id,
+                    'timestamp' => (int)($unixTime . '000'),
+                    'event' => str_replace('%s', $taskOwner->name, $taskOwner === \Auth::user()->id ?
+                        $taskHistoryStatuses['claimed']
+                        : $taskHistoryStatuses['assigned']),
+                    'status' => $taskOwner === \Auth::user()->id ? 'claimed' : 'assigned'
+                ];
+            }
+
+            //update task_history if task is paused or resumed without submitted for QA
+            if (key_exists('paused', $newValues) && (!key_exists('submitted_for_qa', $newValues))) {
+                $taskHistory[] = [
+                    'user' => $taskOwner->_id,
+                    'timestamp' => (int)($unixTime . '000'),
+                    'event' => $newValues['paused'] === true ?
+                        str_replace('%s', ' ', $taskHistoryStatuses['paused'])
+                        : $taskHistoryStatuses['resumed'],
+                    'status' => $newValues['paused'] === true ? 'paused' : 'resumed'
+                ];
+            }
+
+            //update task_history if task is submitted for QA or if task fails QA
+            if (key_exists('submitted_for_qa', $newValues)) {
+                $taskHistory[] = [
+                    'user' => $taskOwner->_id,
+                    'timestamp' => (int)($unixTime . '000'),
+                    'event' => $newValues['submitted_for_qa'] === true ?
+                        $taskHistoryStatuses['qa_ready']
+                        : $taskHistoryStatuses['qa_fail'],
+                    'status' => $newValues['submitted_for_qa'] === true ? 'qa_ready' : 'qa_fail'
+                ];
+                //if task fails QA set task to paused and update task_history for pause
+                if ($newValues['submitted_for_qa'] === false) {
+                    $task->paused = true;
+                    $taskHistory[] = [
+                        'user' => $taskOwner->_id,
+                        'timestamp' => (int)($unixTime . '000'),
+                        'event' => str_replace('%s', 'Task failed QA', $taskHistoryStatuses['paused']),
+                        'status' => 'paused'
+                    ];
+                }
+            }
+
+            //update task_history if task passed QA
+            if (key_exists('passed_qa', $newValues) && $newValues['passed_qa'] === true) {
+                $taskHistory[] = [
+                    'user' => $taskOwner->_id,
+                    'timestamp' => (int)($unixTime . '000'),
+                    'event' => $taskHistoryStatuses['qa_success'],
+                    'status' => 'qa_success'
+                ];
+            }
+
+            $task->task_history = $taskHistory;
+        }
+    }
+}

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -40,6 +40,9 @@ namespace {
                             'App\Events\TaskFinishedEarly' => [
                                 'App\Listeners\TaskFinishedEarly'
                             ],
+                            'App\Events\TaskStatusHistory' => [
+                                'App\Listeners\TaskStatusHistory'
+                            ],
                             'App\Events\GenericModelHistory' => [
                                 'App\Listeners\GenericModelHistory'
                             ]


### PR DESCRIPTION
Write task history on API side using listener

Mimic what FE app does currently, ping @nikola about details if not clear on formatting of task history.

Read task status fields, detect change there and based of the change update task history.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5881d3aa3e5bbe274c5f1553/tasks/5888cb443e5bbe43f963418b)

## Checklist
- [x] Tests covered

## Test notes

Covered all cases (paused, resumed, submitted for QA, failed QA, QA passed) API generates identical task_history updates just like FE now. Except for paused "message" it's set to empty string. It saves like expected in database and it's rendered in FE like expected (now it's duplicated on FE with FE save and API save).