### PR TITLE
Added new role - accountant, permissions allowed only to edit his own profile, login, logout

### DIFF
--- a/database/seeds/AclCollectionSeeder.php
+++ b/database/seeds/AclCollectionSeeder.php
@@ -19,6 +19,7 @@ namespace {
             // Delete previously seeded records from acl collection
             DB::collection('acl')->where('name', 'guest')->delete();
             DB::collection('acl')->where('name', 'standard')->delete();
+            DB::collection('acl')->where('name', 'accountant')->delete();
 
             // Insert records into acl collection
             DB::collection('acl')->insert(
@@ -57,6 +58,26 @@ namespace {
                                 'api/v1/app/{appName}/register',
                                 'api/v1/app/{appName}/login'
                             ],
+                        ]
+                    ],
+                    [
+                        'name' => 'accountant',
+                        'allows' => [
+                            'GET' => [
+                                "api/v1/app/{appName}/profiles",
+                                "api/v1/app/{appName}/profiles/{profiles}",
+                                "api/v1/app/{appName}/configuration"
+                            ],
+                            'PUT' => [
+                                'api/v1/app/{appName}/profiles/changePassword',
+                                'api/v1/app/{appName}/profiles/{profiles}'
+                            ],
+                            'POST' => [
+                                'api/v1/app/{appName}/slack/message'
+                            ],
+                            'PATCH' => [
+                                'api/v1/app/{appName}/profiles/{profiles}'
+                            ]
                         ]
                     ]
                 ]

--- a/database/seeds/UserRolesSeeder.php
+++ b/database/seeds/UserRolesSeeder.php
@@ -20,7 +20,8 @@ namespace {
                             'Standard',
                             'Client',
                             'Employee',
-                            'Admin'
+                            'Admin',
+                            'Accountant'
                         ]
                     ]
                 ]

--- a/database/seeds/ValidationsSeeder.php
+++ b/database/seeds/ValidationsSeeder.php
@@ -70,7 +70,23 @@ namespace {
                                 'GET' => true,
                                 'DELETE' => false,
                                 'POST' => true
-                            ]
+                            ],
+                            'accountant' => [
+                                'editable' => [
+                                    'name',
+                                    'password',
+                                    'email',
+                                    'slack',
+                                    'trello',
+                                    'github',
+                                    'active',
+                                    'valid',
+                                    'skills'
+                                ],
+                                'GET' => true,
+                                'DELETE' => false,
+                                'POST' => false
+                            ],
                         ]
                     ],
                     [


### PR DESCRIPTION
Add new role to profile - `accountant`

We have admin and standard roles defined for now - introduce new one, add acl seeder that allows this role to access just their profile on the platform and change password + login / logout (those routes are public anyway).

Also update validations seeder, allow them just to edit their own profile data

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5881d3aa3e5bbe274c5f1553/tasks/5888c1843e5bbe43f9634163)

## Checklist
- [x] Tests covered

## Test notes

Created new user and added manually in database field 'aclId" => _id(accountant) from acl collection. Tried to change own profile, works fine. Tried to go on some other {resource} routes, permission denied.