### PR TITLE
Feature/send profile performance email to admins and accountants

### DIFF
--- a/app/Console/Commands/EmailProfilePerformance.php
+++ b/app/Console/Commands/EmailProfilePerformance.php
@@ -7,6 +7,7 @@ use App\Profile;
 use App\Services\ProfilePerformance;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Config;
+use Carbon\Carbon;
 
 /**
  * Class EmailProfilePerformance
@@ -19,7 +20,8 @@ class EmailProfilePerformance extends Command
      *
      * @var string
      */
-    protected $signature = 'email:profile:performance {daysAgo : How many days before time of command execution}';
+    protected $signature = 'email:profile:performance {daysAgo : How many days before time of command execution} 
+    {--accountants : If option is passed, value is true, send email to admins and accountants with salary report}';
 
     /**
      * The console command description.
@@ -39,7 +41,13 @@ class EmailProfilePerformance extends Command
 
         $daysAgo = $this->argument('daysAgo');
         $unixNow = (new \DateTime())->format('U');
-        $unixAgo = $unixNow - (int) $daysAgo * 24 * 60 * 60;
+        $unixAgo = $unixNow - (int)$daysAgo * 24 * 60 * 60;
+
+        //if option is passed set date range from 1st day of current month until last day of current month
+        if ($this->option('accountants')) {
+            $unixNow = Carbon::now()->endOfMonth()->format('U');
+            $unixAgo = Carbon::now()->firstOfMonth()->format('U');
+        }
 
         $adminAggregation = [];
 
@@ -49,18 +57,28 @@ class EmailProfilePerformance extends Command
             $data['fromDate'] = \DateTime::createFromFormat('U', $unixAgo)->format('Y-m-d');
             $data['toDate'] = \DateTime::createFromFormat('U', $unixNow)->format('Y-m-d');
 
-            $view = 'emails.profile.performance';
-            $subject = Config::get('mail.private_mail_subject');
+            //if option is not passed send mail to each profile
+            if ($this->option('accountants') === false) {
+                $view = 'emails.profile.performance';
+                $subject = Config::get('mail.private_mail_subject');
 
-            MailSend::send($view, $data, $profile, $subject);
-
+                MailSend::send($view, $data, $profile, $subject);
+            }
             $adminAggregation[] = $data;
         }
 
         $admins = Profile::where('admin', '=', true)->get();
 
+        //if option is passed get all admins and profiles with accountant role
+        if ($this->option('accountants')) {
+            $admins = Profile::where('admin', '=', true)
+                ->orWhere('role', '=', 'accountant')
+                ->get();
+        }
+
         foreach ($admins as $admin) {
-            $view = 'emails.profile.admin-performance-report';
+            $view = $this->option('accountants') ? 'emails.profile.salary-performance-report'
+                : 'emails.profile.admin-performance-report';
             $subject = Config::get('mail.admin_performance_email_subject');
 
             MailSend::send($view, ['reports' => $adminAggregation], $admin, $subject);

--- a/app/Console/Commands/EmailProfilePerformance.php
+++ b/app/Console/Commands/EmailProfilePerformance.php
@@ -67,21 +67,21 @@ class EmailProfilePerformance extends Command
             $adminAggregation[] = $data;
         }
 
-        $admins = Profile::where('admin', '=', true)->get();
+        $overviewRecipients = Profile::where('admin', '=', true)->get();
 
         //if option is passed get all admins and profiles with accountant role
         if ($this->option('accountants')) {
-            $admins = Profile::where('admin', '=', true)
+            $overviewRecipients = Profile::where('admin', '=', true)
                 ->orWhere('role', '=', 'accountant')
                 ->get();
         }
 
-        foreach ($admins as $admin) {
+        foreach ($overviewRecipients as $recipient) {
             $view = $this->option('accountants') ? 'emails.profile.salary-performance-report'
                 : 'emails.profile.admin-performance-report';
             $subject = Config::get('mail.admin_performance_email_subject');
 
-            MailSend::send($view, ['reports' => $adminAggregation], $admin, $subject);
+            MailSend::send($view, ['reports' => $adminAggregation], $recipient, $subject);
         }
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Helpers\WorkDays;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Carbon\Carbon;
@@ -45,7 +46,9 @@ class Kernel extends ConsoleKernel
             ->at('08:00');
 
         $schedule->command('email:profile:performance 0 --accountants')->when(function () {
-            return Carbon::parse(LastWorkDay::getLastWorkingDay())->isToday();
+            $workDays = WorkDays::getWorkDays();
+            $lastWorkDay = end($workDays);
+            return Carbon::parse($lastWorkDay)->isToday();
         });
 
         $schedule->command('employee:minimum:check')

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,8 @@ namespace App\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Carbon\Carbon;
+use App\Helpers\LastWorkDay;
 
 class Kernel extends ConsoleKernel
 {
@@ -41,6 +43,11 @@ class Kernel extends ConsoleKernel
             ->weekly()
             ->mondays()
             ->at('08:00');
+
+        $schedule->command('email:profile:performance 0 --accountants')->when(function () {
+            return Carbon::parse(LastWorkDay::getLastWorkingDay())->isToday();
+        });
+
 
         $schedule->command('employee:minimum:check')
             ->monthlyOn(1, '08:00');

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -48,7 +48,6 @@ class Kernel extends ConsoleKernel
             return Carbon::parse(LastWorkDay::getLastWorkingDay())->isToday();
         });
 
-
         $schedule->command('employee:minimum:check')
             ->monthlyOn(1, '08:00');
     }

--- a/app/Helpers/LastWorkDay.php
+++ b/app/Helpers/LastWorkDay.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Helpers;
+
+use Carbon\Carbon;
+
+/**
+ * Return date of last day of month that is not weekend
+ * Class LastWorkDay
+ * @package App\Helpers
+ */
+class LastWorkDay
+{
+    public static function getLastWorkingDay()
+    {
+        $firstDayOfMonth  = Carbon::now()->firstOfMonth();
+        $lastDayOfMonth = Carbon::now()->endOfMonth();
+
+        $dates = [];
+
+        for ($date = $firstDayOfMonth; $date->lte($lastDayOfMonth); $date->addDay()) {
+            if ($date->isWeekday()) {
+                $dates[] = $date->format('Y-m-d');
+            }
+        }
+
+        return end($dates);
+    }
+}

--- a/app/Helpers/WorkDays.php
+++ b/app/Helpers/WorkDays.php
@@ -5,15 +5,15 @@ namespace App\Helpers;
 use Carbon\Carbon;
 
 /**
- * Return date of last day of month that is not weekend
- * Class LastWorkDay
+ * Return list of work days (week days)
+ * Class WorkDays
  * @package App\Helpers
  */
-class LastWorkDay
+class WorkDays
 {
-    public static function getLastWorkingDay()
+    public static function getWorkDays()
     {
-        $firstDayOfMonth  = Carbon::now()->firstOfMonth();
+        $firstDayOfMonth = Carbon::now()->firstOfMonth();
         $lastDayOfMonth = Carbon::now()->endOfMonth();
 
         $dates = [];
@@ -24,6 +24,6 @@ class LastWorkDay
             }
         }
 
-        return end($dates);
+        return $dates;
     }
 }

--- a/app/Services/ProfilePerformance.php
+++ b/app/Services/ProfilePerformance.php
@@ -334,10 +334,10 @@ class ProfilePerformance
         $costGrossMinimum = $this->calculateSalaryCostForAmount($realPayout, $coefficient);
         $grossMinimum = $this->calculateSalaryGrossForAmount($costGrossMinimum);
 
-        $aggregated['costTotal'] = round($costReal, 4);
-        $aggregated['minimalGrossPayout'] = round($grossMinimum, 4);
-        $aggregated['realGrossPayout'] = round($grossReal, 4);
-        $aggregated['grossBonusPayout'] = round($grossReal - $grossMinimum, 4);
+        $aggregated['costTotal'] = round($costReal, 2);
+        $aggregated['minimalGrossPayout'] = round($grossMinimum, 2);
+        $aggregated['realGrossPayout'] = round($grossReal, 2);
+        $aggregated['grossBonusPayout'] = round($grossReal - $grossMinimum, 2);
         $aggregated['costXpBasedPayout'] = $xpBasedPayout;
         $aggregated['employeeRole'] = $role;
         $aggregated['roleMinimumReached'] = $grossReal > $grossMinimum;

--- a/resources/views/emails/profile/salary-performance-report-html.blade.php
+++ b/resources/views/emails/profile/salary-performance-report-html.blade.php
@@ -1,0 +1,18 @@
+<div style="padding: 20px">
+    <p>
+        Employee : <strong>{{$name}}</strong>,<br/>
+        Here are salary stats for period of <strong>{{$fromDate}}</strong> to <strong>{{$toDate}}</strong>:
+    </p>
+
+    <p>
+        Base gross salary: <strong>{{$realGrossPayout}} HRK</strong>
+    </p>
+
+    <p>
+        Gross bonus: <strong>{{$grossBonusPayout}} HRK</strong>
+    </p>
+
+    <p>
+        Gross total: <strong>{{$realGrossPayout + $grossBonusPayout}} HRK</strong>
+    </p>
+</div>

--- a/resources/views/emails/profile/salary-performance-report.blade.php
+++ b/resources/views/emails/profile/salary-performance-report.blade.php
@@ -1,0 +1,11 @@
+@extends('email-layout')
+
+@section('content')
+
+    @foreach($reports as $report)
+
+        @include('emails.profile.salary-performance-report-html', $report)
+
+    @endforeach
+
+@endsection


### PR DESCRIPTION
Send profile performance email to admins and accountant roles on last day of the month

Use ProfilePerformance service to aggregate data, create new email template (similar to weekly performance aggregation) and output

Base gross salary: 123.45
Gross bonus: 12.34
Gross total: <Base + Bonus>

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5881d3aa3e5bbe274c5f1553/tasks/5888c2193e5bbe696319f330)

## Checklist
- [x] Tests covered

## Test notes

Tested with and without adding option --accountants (when set it's true, when not passed it's false). Everything working as expected. When option is passed it sends emails with salary performance to accountants and admins, when not passed it sends performance stats emails to each user and "reports" mail to admins. 

## Screenshots

If applicable, add screenshots of what you did.