### PR TITLE
Notify user on slack when added/removed from project

### DIFF
--- a/app/Events/ProjectMembers.php
+++ b/app/Events/ProjectMembers.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Events\Event;
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class ProjectMembers extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * ProjectMembers constructor.
+     * @param GenericModel $model
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Listeners/ProjectMembers.php
+++ b/app/Listeners/ProjectMembers.php
@@ -9,6 +9,9 @@ use Vluzrmos\SlackApi\Facades\SlackChat;
 
 class ProjectMembers
 {
+    const STATUS_ADDED = true;
+    const STATUS_REMOVED = false;
+    
     /**
      * Handle the event
      * @param \App\Events\ProjectMembers $event
@@ -26,7 +29,7 @@ class ProjectMembers
                     if (!in_array($newMemberId, $oldFields['members'])) {
                         $member = Profile::find($newMemberId);
                         if ($member->slack) {
-                            $this->slackMessageUser($member, $project, true);
+                            $this->slackMessageUser($member, $project, self::STATUS_ADDED);
                         }
                     }
                 }
@@ -35,7 +38,7 @@ class ProjectMembers
                     if (!in_array($oldMemberId, $updatedFields['members'])) {
                         $member = Profile::find($oldMemberId);
                         if ($member->slack) {
-                            $this->slackMessageUser($member, $project, false);
+                            $this->slackMessageUser($member, $project, self::STATUS_REMOVED);
                         }
                     }
                 }
@@ -54,7 +57,7 @@ class ProjectMembers
         $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
         $recipient = '@' . $profile->slack;
         $message = 'Hey, you\'ve just been'
-            . ($status === true ? ' added to ' : ' removed from ')
+            . ($status === self::STATUS_ADDED ? ' added to ' : ' removed from ')
             . 'project '
             . $project->name
             . ' ('

--- a/app/Listeners/ProjectMembers.php
+++ b/app/Listeners/ProjectMembers.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Listeners;
+
+use App\GenericModel;
+use App\Profile;
+use Illuminate\Support\Facades\Config;
+use Vluzrmos\SlackApi\Facades\SlackChat;
+
+class ProjectMembers
+{
+    /**
+     * Handle the event
+     * @param \App\Events\ProjectMembers $event
+     */
+    public function handle(\App\Events\ProjectMembers $event)
+    {
+        $project = $event->model;
+
+        if ($project->isDirty()) {
+            $oldFields = $project->getOriginal();
+            $updatedFields = $project->getDirty();
+            if ($project['collection'] === 'projects' && key_exists('members', $updatedFields)) {
+                //if user is added to project send slack notification
+                foreach ($updatedFields['members'] as $newMemberId) {
+                    if (!in_array($newMemberId, $oldFields['members'])) {
+                        $member = Profile::find($newMemberId);
+                        if ($member->slack) {
+                            $this->slackMessageUser($member, $project, true);
+                        }
+                    }
+                }
+                //if user is removed from project send slack notification
+                foreach ($oldFields['members'] as $oldMemberId) {
+                    if (!in_array($oldMemberId, $updatedFields['members'])) {
+                        $member = Profile::find($oldMemberId);
+                        if ($member->slack) {
+                            $this->slackMessageUser($member, $project, false);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Helper method to notify user on Slack if added or removed from project
+     * @param Profile $profile
+     * @param GenericModel $project
+     * @param $status
+     */
+    private function slackMessageUser(Profile $profile, GenericModel $project, $status)
+    {
+        $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
+        $recipient = '@' . $profile->slack;
+        $message = 'Hey, you\'ve just been'
+            . ($status === true ? ' added to ' : ' removed from ')
+            . 'project '
+            . $project->name
+            . ' ('
+            . $webDomain
+            . 'projects/'
+            . $project->_id
+            . ')';
+
+        SlackChat::message($recipient, $message);
+    }
+}

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -42,6 +42,15 @@ namespace {
                             ],
                             'App\Events\GenericModelHistory' => [
                                 'App\Listeners\GenericModelHistory'
+                            ],
+                        ]
+                    ],
+                    [
+                        'resource' => 'projects',
+                        'event' => 'update',
+                        'listeners' => [
+                            'App\Events\ProjectMembers' => [
+                                'App\Listeners\ProjectMembers'
                             ]
                         ]
                     ],


### PR DESCRIPTION
Listener to notify project member on adding / removing from project

Ping them on Slack with message: `Hey, you've just been <added/removed> <to/from> project <projectName> (<linkToProject>)`

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/588cc80e3e5bbe40061c06f1/tasks/588e0e2f3e5bbe40061c07c9)

## Checklist

- [x] Tests covered

## Test notes

Try to create project locally and add or remove members... Working as expected, when removed sends slack message that is removed, when added sends slack message that user is added to certain project.