### PR TITLE
Ping admins / PO about approaching task deadline 2 days before deadline

### DIFF
--- a/app/Console/Commands/NotifyAdminsTaskDeadline.php
+++ b/app/Console/Commands/NotifyAdminsTaskDeadline.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\GenericModel;
+use App\Helpers\InputHandler;
+use App\Profile;
+use Illuminate\Console\Command;
+use Vluzrmos\SlackApi\Facades\SlackChat;
+
+class NotifyAdminsTaskDeadline extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ping:admins:task:deadline';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Ping admins / PO on slack about approaching task deadline 2 days before deadline';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        GenericModel::setCollection('tasks');
+        $tasks = GenericModel::all();
+
+        $unixDateNow = (new \DateTime())->format('U');
+        $unixTwoDaysFromNow = $unixDateNow + 48 * 60 * 60;
+        $twoDaysFromNowDate = \DateTime::createFromFormat('U', $unixTwoDaysFromNow)->format('Y-m-d');
+        foreach ($tasks as $task) {
+            if (!empty($task->due_date) && $twoDaysFromNowDate
+                === \DateTime::createFromFormat('U', InputHandler::getUnixTimestamp($task->due_date))->format('Y-m-d')
+            ) {
+                GenericModel::setCollection('projects');
+                $taskProject = GenericModel::where('_id', '=', $task->project_id)->first();
+                $adminsAndPo = Profile::where('admin', '=', true)
+                    ->orWhere('_id', '=', $taskProject->acceptedBy)
+                    ->get();
+
+                foreach ($adminsAndPo as $user) {
+                    if ($user->slack) {
+                        $taskDueDate = \DateTime::createFromFormat('U', InputHandler::getUnixTimestamp($task->due_date))
+                            ->format('Y-m-d');
+                        $recipient = '@' . $user->slack;
+                        $message = 'Hey, task *'
+                            . $task->title
+                            . '* on project *'
+                            . $taskProject->name
+                            . '* deadline is in *2 days* '
+                            . '(*'
+                            . $taskDueDate
+                            . '*)';
+                        SlackChat::message($recipient, $message);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -20,7 +20,8 @@ class Kernel extends ConsoleKernel
         Commands\XpDeduction::class,
         Commands\UnfinishedTasks::class,
         Commands\EmailProfilePerformance::class,
-        Commands\MonthlyMinimumCheck::class
+        Commands\MonthlyMinimumCheck::class,
+        Commands\NotifyAdminsTaskDeadline::class
     ];
 
     /**
@@ -53,5 +54,8 @@ class Kernel extends ConsoleKernel
 
         $schedule->command('employee:minimum:check')
             ->monthlyOn(1, '08:00');
+
+        $schedule->command('ping:admins:task:deadline')
+            ->dailyAt('09:00');
     }
 }


### PR DESCRIPTION
Ping admins / PO about approaching task deadline 2 days before deadline

Similar to the reminder cron we had, just ping admins / project owner instead of everyone.

Note that on some tasks deadline might not be set, skip those and make sure it doesn't break the code.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/588cc80e3e5bbe40061c06f1/tasks/588e12943e5bbe40061c07ed)

## Checklist
- [x] Tests covered

## Test notes

Created few projects with few sprints and tasks. Few tasks deadline set to 2017-02-01 (2 days from now), rest set to some other dates. Also some tasks created without due_date. Works as expected, sends message on slack to PO and admins about task name, project name and deadline date.
