### PR TITLE
Validation seeder for multiple applications support

### DIFF
--- a/app/Helpers/WorkDays.php
+++ b/app/Helpers/WorkDays.php
@@ -5,12 +5,16 @@ namespace App\Helpers;
 use Carbon\Carbon;
 
 /**
- * Return list of work days (week days)
  * Class WorkDays
  * @package App\Helpers
  */
 class WorkDays
 {
+    /**
+     * Return list of work days (week days)
+     * Class WorkDays
+     * @package App\Helpers
+     */
     public static function getWorkDays()
     {
         $firstDayOfMonth = Carbon::now()->firstOfMonth();

--- a/app/Http/Middleware/MultipleAppSupport.php
+++ b/app/Http/Middleware/MultipleAppSupport.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Support\Facades\Config;
 
 class MultipleAppSupport
 {
@@ -16,10 +17,15 @@ class MultipleAppSupport
     public function handle($request, Closure $next)
     {
         $requestDbName = strtolower($request->route('appName'));
-        $dbName = \Config::get('database.connections.mongodb.database');
+        $coreDbName = Config::get('sharedSettings.internalConfiguration.coreDatabaseName');
+        if ($requestDbName === $coreDbName) {
+            return $next($request);
+        }
+
+        $dbName = Config::get('database.connections.mongodb.database');
 
         if ($dbName !== $requestDbName) {
-            \Config::set('database.connections.mongodb.database', $requestDbName);
+            Config::set('database.connections.mongodb.database', $requestDbName);
         }
 
         return $next($request);

--- a/app/Http/Middleware/MultipleAppSupport.php
+++ b/app/Http/Middleware/MultipleAppSupport.php
@@ -5,7 +5,6 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
-use MongoDB\Database;
 
 class MultipleAppSupport
 {

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -54,6 +54,7 @@ Route::group(['prefix' => 'api/v1/app/{appName}', 'middleware' => ['multiple-app
         Route::post('email', 'EmailController@sendEmail');
         Route::post('upload', 'FileUploadController@uploadFile');
 
+
         /**
          * Generic resources routes
          *
@@ -65,6 +66,7 @@ Route::group(['prefix' => 'api/v1/app/{appName}', 'middleware' => ['multiple-app
         Route::post('{resource}', 'GenericResourceController@store')->middleware(['the-shop.genericResource', 'adapters']);
         Route::put('{resource}/{id}', 'GenericResourceController@update')->middleware(['the-shop.genericResource', 'adapters']);
         Route::delete('{resource}/{id}', 'GenericResourceController@destroy')->middleware(['the-shop.genericResource', 'adapters']);
+        Route::post('{resource}/register', 'GenericResourceController@store')->middleware(['the-shop.genericResource', 'adapters']);
     });
 });
 

--- a/config/database.php
+++ b/config/database.php
@@ -57,6 +57,19 @@ return [
                 'db' => 'admin' // sets the authentication database required by mongo 3
             ]
         ],
+
+        'mongodbAdmin' => [
+            'driver' => 'mongodb',
+            'host' => env('DB_HOST', '127.0.0.1'),
+            'port' => env('DB_PORT', 27017),
+            'database' => 'admin',
+            'username' => env('DB_USERNAME', ''),
+            'password' => env('DB_PASSWORD', ''),
+            'options' => [
+                'db' => 'admin' // sets the authentication database required by mongo 3
+            ]
+        ],
+
         'sqlite' => [
             'driver' => 'sqlite',
             'database' => database_path('database.sqlite'),

--- a/config/sharedSettings.php
+++ b/config/sharedSettings.php
@@ -92,7 +92,8 @@ return [
             'Medium',
             'Low'
         ],
-        'floatPrecision' => 2
+        'floatPrecision' => 2,
+        'coreDatabaseName' => 'core'
     ],
 
     /**

--- a/database/seeds/AclCollectionSeeder.php
+++ b/database/seeds/AclCollectionSeeder.php
@@ -79,7 +79,15 @@ namespace {
                                 'api/v1/app/{appName}/profiles/{profiles}'
                             ]
                         ]
-                    ]
+                    ],
+                    [
+                        'name' => 'admin',
+                        'allows' => [
+                            'POST' => [
+                                'api/v1/app/{appName}/{resource}/register'
+                            ],
+                        ]
+                    ],
                 ]
             );
         }

--- a/database/seeds/ApplicationRegistrationSeeder.php
+++ b/database/seeds/ApplicationRegistrationSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace {
+
+    use Illuminate\Database\Seeder;
+    use Illuminate\Support\Facades\Config;
+    use Illuminate\Support\Facades\Schema;
+
+    class ApplicationRegistrationSeeder extends Seeder
+    {
+        /**
+         * Run the database seeds.
+         *
+         * @return void
+         */
+        public function run()
+        {
+            $coreDatabaseName = Config::get('sharedSettings.internalConfiguration.coreDatabaseName');
+            Config::set('database.connections.mongodb.database', $coreDatabaseName);
+            $defaultDb = Config::get('database.default');
+            DB::purge($defaultDb);
+            DB::connection($defaultDb);
+            Schema::create('applications');
+        }
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -4,6 +4,7 @@ namespace
 
 {
     use Illuminate\Database\Seeder;
+    use Illuminate\Support\Facades\Artisan;
 
     class DatabaseSeeder extends Seeder
     {
@@ -19,6 +20,7 @@ namespace
             $this->call(ListenerRulesSeeder::class);
             $this->call(AdapterRulesSeeder::class);
             $this->call(UserRolesSeeder::class);
+            $this->call(ApplicationRegistrationSeeder::class);
         }
     }
 }

--- a/database/seeds/ValidationsSeeder.php
+++ b/database/seeds/ValidationsSeeder.php
@@ -21,6 +21,8 @@ namespace {
             DB::collection('validations')->where('resource', 'xp')->delete();
             DB::collection('validations')->where('resource', 'comments')->delete();
             DB::collection('validations')->where('resource', 'uploads')->delete();
+            DB::collection('validations')->where('resource', 'applications')->delete();
+
             DB::collection('validations')->delete();
 
             // Insert records into validations collection
@@ -209,6 +211,22 @@ namespace {
                             'fileUrl' => 'required|string',
                         ],
                         'resource' => 'uploads',
+                        'acl' => [
+                            'standard' => [
+                                'editable' => [],
+                                'GET' => true,
+                                'DELETE' => false,
+                                'POST' => false,
+                                'updateOwn' => false
+                            ]
+                        ]
+                    ],
+                    [
+                        'fields' => [
+                            'appName' => 'required:string',
+                            'dbSlug' => 'required:string'
+                        ],
+                        'resource' => 'applications',
                         'acl' => [
                             'standard' => [
                                 'editable' => [],


### PR DESCRIPTION
# Task name

Validation seeder for multiple applications support

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/588cc80e3e5bbe40061c06f1/tasks/587a91b83e5bbe4334746fdd)

## Test notes

Acl middleware needs to be reformated cause it allows admins to go on all routes, acl validator allows admins to put any fields into "core" regardless of definition in ValidationSeeder, seeder creates new database "core" with empty collection applications. Admin only can create new records inside that database trough GenericResourceController.