### PR TITLE
Slack helper

### DIFF
--- a/app/Console/Commands/TaskPriority.php
+++ b/app/Console/Commands/TaskPriority.php
@@ -45,65 +45,41 @@ class TaskPriority extends Command
         $date = new \DateTime();
         $cronTime = $date->format('U');
 
+        $priorityMapping = \Config::get('sharedSettings.internalConfiguration.priorityMapping');
+
         $message = [];
         $recipient = ['@mvoloder'];
         $highPriorityTask = [];
         $mediumPriorityTask = [];
         $lowPriorityTask = [];
+
         $priority = \Config::get('sharedSettings.internalConfiguration.taskPriorities');
 
         $slack = new Slack();
         GenericModel::setCollection('slackMessages');
-        $slackMessage = GenericModel::create();
 
         foreach ($tasks as $task) {
             if (empty($task->owner) && ($task->priority === 'High')) {
-                    $highPriorityTask[] = $task->id;
-                    $message[] = "High priority task : " . $task->id;
-                    $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+                $highPriorityTask[] = $task->id;
+                $message[] = "High priority task : " . $task->id;
+                $slack->sendSlackPriorityMessage($recipient, $message, $priority);
             }
             if (empty($task->owner) && ($task->priority === 'Medium')) {
+                $slackMessage = GenericModel::create();
                 $mediumPriorityTask[] = $task->id;
-                $slackMessage->mediumPriority = "Medium priority task : " . $task->id;
+                $slackMessage->mediumPriorityTask = $task->id;
+                $slackMessage->save();
+                $message[] = "Medium priority task : " . $task->id;
                 $slack->sendSlackPriorityMessage($recipient, $message, $priority);
             }
             if (empty($task->owner) && ($task->priority === 'Low')) {
+                $slackMessage = GenericModel::create();
                 $lowPriorityTask[] = $task->id;
-                $slackMessage->lowPriority = "Low priority task : " . $task->id;
+                $slackMessage->lowPriority = $task->id;
+                $slackMessage->save();
+                $message[] = "Low priority task : " . $task->id;
                 $slack->sendSlackPriorityMessage($recipient, $message, $priority);
             }
         }
-
-//        if ($priority ==! 'High'){
-//            foreach ($tasks as $task){
-//                if (empty($task->owner)){
-//                    $unassignedTasks[$task->id] = $task->priority;
-//                }
-//            }
-//
-//            GenericModel::setCollection('slackMessages');
-//            $slackMessages = GenericModel::create();
-//
-//            foreach ($unassignedTasks as $key => $value){
-//                if ($value === \Config::get('sharedSettings.taskPriority.Medium')){
-//                    $slackMessages->mediumPriority = "Medium priority task : " . $key;
-//                    $message[$value] = $key;
-//                }elseif ($value === \Config::get('sharedSettings.taskPriority.Low')){
-//                    $slackMessages->lowPriority = "Low priority task : " . $key;
-//                    $message[$value] = $key;
-//                }
-//                $slackMessages->save();
-//            }
-//            $slack->sendSlackPriorityMessage($recipient, $message, $priority);
-//        }
-//
-//        if ($priority === 'High'){
-//            foreach ($tasks as $task){
-//                if (empty($task->owner) && $cronTime === \Config::get('sharedSettings.priorityMapping.1')){
-//                    $message = "High priority task : " . $task->id;
-//                }
-//                $slack->sendSlackPriorityMessage($recipient, $message, $priority);
-//            }
-//        }
     }
 }

--- a/app/Console/Commands/TaskPriority.php
+++ b/app/Console/Commands/TaskPriority.php
@@ -68,7 +68,6 @@ class TaskPriority extends Command
 
         $p = $this->argument('priority');
 
-
         if (intval($p) === intval($priorityMapping['High'])) {
             foreach ($highPriority as $message) {
                 $slack->sendSlackPriorityMessage($recipient, $message, $priority);

--- a/app/Console/Commands/TaskPriority.php
+++ b/app/Console/Commands/TaskPriority.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Helpers\Slack;
+use Illuminate\Console\Command;
+use App\GenericModel;
+
+class TaskPriority extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'slackMessage:send';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Cron that sends task priority slack messages';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        GenericModel::setCollection('tasks');
+        $tasks = GenericModel::all();
+
+        $date = new \DateTime();
+        $cronTime = $date->format('U');
+
+        $message = [];
+        $recipient = ['@mvoloder'];
+        $highPriorityTask = [];
+        $mediumPriorityTask = [];
+        $lowPriorityTask = [];
+        $priority = \Config::get('sharedSettings.internalConfiguration.taskPriorities');
+
+        $slack = new Slack();
+        GenericModel::setCollection('slackMessages');
+        $slackMessage = GenericModel::create();
+
+        foreach ($tasks as $task) {
+            if (empty($task->owner) && ($task->priority === 'High')) {
+                    $highPriorityTask[] = $task->id;
+                    $message[] = "High priority task : " . $task->id;
+                    $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+            }
+            if (empty($task->owner) && ($task->priority === 'Medium')) {
+                $mediumPriorityTask[] = $task->id;
+                $slackMessage->mediumPriority = "Medium priority task : " . $task->id;
+                $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+            }
+            if (empty($task->owner) && ($task->priority === 'Low')) {
+                $lowPriorityTask[] = $task->id;
+                $slackMessage->lowPriority = "Low priority task : " . $task->id;
+                $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+            }
+        }
+
+//        if ($priority ==! 'High'){
+//            foreach ($tasks as $task){
+//                if (empty($task->owner)){
+//                    $unassignedTasks[$task->id] = $task->priority;
+//                }
+//            }
+//
+//            GenericModel::setCollection('slackMessages');
+//            $slackMessages = GenericModel::create();
+//
+//            foreach ($unassignedTasks as $key => $value){
+//                if ($value === \Config::get('sharedSettings.taskPriority.Medium')){
+//                    $slackMessages->mediumPriority = "Medium priority task : " . $key;
+//                    $message[$value] = $key;
+//                }elseif ($value === \Config::get('sharedSettings.taskPriority.Low')){
+//                    $slackMessages->lowPriority = "Low priority task : " . $key;
+//                    $message[$value] = $key;
+//                }
+//                $slackMessages->save();
+//            }
+//            $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+//        }
+//
+//        if ($priority === 'High'){
+//            foreach ($tasks as $task){
+//                if (empty($task->owner) && $cronTime === \Config::get('sharedSettings.priorityMapping.1')){
+//                    $message = "High priority task : " . $task->id;
+//                }
+//                $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+//            }
+//        }
+    }
+}

--- a/app/Console/Commands/TaskPriority.php
+++ b/app/Console/Commands/TaskPriority.php
@@ -13,7 +13,7 @@ class TaskPriority extends Command
      *
      * @var string
      */
-    protected $signature = 'slackMessage:send';
+    protected $signature = 'slackMessage:send {priority}';
 
     /**
      * The console command description.
@@ -44,6 +44,8 @@ class TaskPriority extends Command
 
         $priority = \Config::get('sharedSettings.internalConfiguration.taskPriorities');
 
+        $priorityMapping = \Config::get('sharedSettings.internalConfiguration.priorityMapping');
+
         $recipient = '@mvoloder';
         $highPriority = [];
         $mediumPriority = [];
@@ -64,22 +66,31 @@ class TaskPriority extends Command
         $slack = new Slack();
         GenericModel::setCollection('slackMessages');
 
-        foreach ($highPriority as $message) {
-            $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+        $p = $this->argument('priority');
+
+
+        if (intval($p) === intval($priorityMapping['High'])) {
+            foreach ($highPriority as $message) {
+                $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+            }
         }
 
-        foreach ($mediumPriority as $message) {
-            $slackMessage = GenericModel::create();
-            $slackMessage->mediumPriority = $message;
-            $slackMessage->save();
-            $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+        if (intval($p) === intval($priorityMapping['Medium'])) {
+            foreach ($mediumPriority as $message) {
+                $slackMessage = GenericModel::create();
+                $slackMessage->mediumPriority = $message;
+                $slackMessage->save();
+                $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+            }
         }
 
-        foreach ($lowPriority as $message) {
-            $slackMessage = GenericModel::create();
-            $slackMessage->lowPriority = $message;
-            $slackMessage->save();
-            $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+        if (intval($p) === intval($priorityMapping['Low'])) {
+            foreach ($lowPriority as $message) {
+                $slackMessage = GenericModel::create();
+                $slackMessage->lowPriority = $message;
+                $slackMessage->save();
+                $slack->sendSlackPriorityMessage($recipient, $message, $priority);
+            }
         }
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -20,7 +20,8 @@ class Kernel extends ConsoleKernel
         Commands\XpDeduction::class,
         Commands\UnfinishedTasks::class,
         Commands\EmailProfilePerformance::class,
-        Commands\MonthlyMinimumCheck::class
+        Commands\MonthlyMinimumCheck::class,
+        Commands\TaskPriority::class
     ];
 
     /**
@@ -53,5 +54,8 @@ class Kernel extends ConsoleKernel
 
         $schedule->command('employee:minimum:check')
             ->monthlyOn(1, '08:00');
+
+        $schedule->command('slackMessage:send')
+            ->everyThirtyMinutes();
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -55,7 +55,13 @@ class Kernel extends ConsoleKernel
         $schedule->command('employee:minimum:check')
             ->monthlyOn(1, '08:00');
 
-        $schedule->command('slackMessage:send')
-            ->twiceDaily(9, 14);
+        $schedule->command('slackMessage:send 0')
+            ->hourly();
+
+        $schedule->command('slackMessage:send 30')
+            ->hourly();
+
+        $schedule->command('slackMessage:send 120')
+            ->hourly();
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -56,6 +56,6 @@ class Kernel extends ConsoleKernel
             ->monthlyOn(1, '08:00');
 
         $schedule->command('slackMessage:send')
-            ->everyThirtyMinutes();
+            ->everyMinute();
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -56,6 +56,6 @@ class Kernel extends ConsoleKernel
             ->monthlyOn(1, '08:00');
 
         $schedule->command('slackMessage:send')
-            ->everyMinute();
+            ->twiceDaily(9, 14);
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -55,13 +55,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('employee:minimum:check')
             ->monthlyOn(1, '08:00');
 
-        $schedule->command('slackMessage:send 0')
-            ->hourly();
-
-        $schedule->command('slackMessage:send 30')
-            ->hourly();
-
-        $schedule->command('slackMessage:send 120')
+        $schedule->command('slackMessage:send priority')
             ->hourly();
     }
 }

--- a/app/Helpers/Slack.php
+++ b/app/Helpers/Slack.php
@@ -2,8 +2,6 @@
 
 namespace App\Helpers;
 
-use App\GenericModel;
-
 class Slack
 {
 
@@ -13,11 +11,6 @@ class Slack
 
     public function sendSlackPriorityMessage($recipient, $message, $priority)
     {
-
-        if ($priority === self::HIGH_PRIORITY) {
-            \SlackChat::message($recipient, $message, $priority);
-        } else {
-            \SlackChat::message($recipient, $message, $priority);
-        }
+        \SlackChat::message($recipient, $message, $priority);
     }
 }

--- a/app/Helpers/Slack.php
+++ b/app/Helpers/Slack.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Helpers;
+
+use App\GenericModel;
+
+class Slack
+{
+
+    const HIGH_PRIORITY = 1;
+    const MEDIUM_PRIORITY = 2;
+    const LOW_PRIORITY = 3;
+
+    public function sendSlackPriorityMessage($recipient, $message, $priority)
+    {
+        print_r($priority);
+        if ($priority !== self::HIGH_PRIORITY) {
+            \SlackChat::message($recipient, $message, $priority);
+        } elseif ($priority === self::HIGH_PRIORITY) {
+            \SlackChat::message($recipient, $message, $priority);
+        }
+    }
+}

--- a/app/Helpers/Slack.php
+++ b/app/Helpers/Slack.php
@@ -7,16 +7,16 @@ use App\GenericModel;
 class Slack
 {
 
-    const HIGH_PRIORITY = 1;
-    const MEDIUM_PRIORITY = 2;
-    const LOW_PRIORITY = 3;
+    const HIGH_PRIORITY = 'High';
+    const MEDIUM_PRIORITY = 'Medium';
+    const LOW_PRIORITY = 'Low';
 
     public function sendSlackPriorityMessage($recipient, $message, $priority)
     {
-        print_r($priority);
-        if ($priority !== self::HIGH_PRIORITY) {
+
+        if ($priority === self::HIGH_PRIORITY) {
             \SlackChat::message($recipient, $message, $priority);
-        } elseif ($priority === self::HIGH_PRIORITY) {
+        } else {
             \SlackChat::message($recipient, $message, $priority);
         }
     }

--- a/app/Helpers/Slack.php
+++ b/app/Helpers/Slack.php
@@ -2,14 +2,16 @@
 
 namespace App\Helpers;
 
+use App\GenericModel;
+
 class Slack
 {
 
-    const HIGH_PRIORITY = 'High';
-    const MEDIUM_PRIORITY = 'Medium';
-    const LOW_PRIORITY = 'Low';
+    const HIGH_PRIORITY = 0;
+    const MEDIUM_PRIORITY = 30;
+    const LOW_PRIORITY = 120;
 
-    public function sendSlackPriorityMessage($recipient, $message, $priority)
+    public function sendMessage($recipient, $message, $priority)
     {
         \SlackChat::message($recipient, $message, $priority);
     }

--- a/config/sharedSettings.php
+++ b/config/sharedSettings.php
@@ -94,9 +94,9 @@ return [
         ],
         'floatPrecision' => 2,
         'priorityMapping' => [
-            '1' => 0,
-            '2' => 30,
-            '3' => 120
+            'High' => 0,
+            'Medium' => 30,
+            'Low' => 120
         ]
     ],
 

--- a/config/sharedSettings.php
+++ b/config/sharedSettings.php
@@ -92,7 +92,12 @@ return [
             'Medium',
             'Low'
         ],
-        'floatPrecision' => 2
+        'floatPrecision' => 2,
+        'priorityMapping' => [
+            '1' => 0,
+            '2' => 30,
+            '3' => 120
+        ]
     ],
 
     /**


### PR DESCRIPTION
Add Slack helper for sending messages with support for priority


For testing purpose recipient for now is just my channel it's easily fixed.

should return High priority tasks when argument passed is 0, Medium priority tasks with argument 30, and Low priority tasks with argument 120.  


[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/588cc80e3e5bbe40061c06f1/tasks/5888c9873e5bbe7ebe3faf6e)



