### PR TITLE
Improved query to accept multiple search params

### DIFF
--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -30,13 +30,20 @@ class GenericResourceController extends Controller
         $errors = [];
 
         // Validate query params based on request params
-        if ($request->has('searchField') && $request->has('searchQuery')) {
-            $searchField = $request->get('searchField');
-            $searchQuery = '%' . $request->get('searchQuery') . '%';
-            if ($request->input('searchExact', null)) {
-                $query->where($searchField, '=', $request->get('searchQuery'));
-            } else {
-                $query->where($searchField, 'LIKE', $searchQuery);
+        if (!empty($request->all())) {
+            $allParams = $request->all();
+            $skipParams = [
+                'orderBy',
+                'orderDirection',
+                'offset',
+                'limit'
+            ];
+
+            foreach ($allParams as $key => $value) {
+                if (in_array($key, $skipParams)) {
+                    continue;
+                }
+                $query->where($key, '=', $value);
             }
         }
 

--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -43,7 +43,11 @@ class GenericResourceController extends Controller
                 if (in_array($key, $skipParams)) {
                     continue;
                 }
-                $query->where($key, '=', $value);
+                if (is_array($value)) {
+                    $query->whereIn($key, $value);
+                } else {
+                    $query->where($key, '=', $value);
+                }
             }
         }
 


### PR DESCRIPTION
GenericResourceController::index() filtering improvements

check all query parameters, iterate them and based of them if there's value set query by all.

Keep the support for `offset`, `limit`, `orderDirection` and `orderBy`

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/588cc80e3e5bbe40061c06f1/tasks/58930b8f3e5bbe39e53510f3)

## Checklist
- [x] Tests covered

## Test notes
Checks all params passed, iterate them, skip defuault params 'offset', 'limit', 'orderDirection' and 'orderBy'. Binds passed params to query. Working as expected.