### PR TITLE
Updated xp deduction to deduct xp only from standard user role

### DIFF
--- a/app/Console/Commands/XpDeduction.php
+++ b/app/Console/Commands/XpDeduction.php
@@ -85,7 +85,7 @@ class XpDeduction extends Command
                     continue;
                 }
 
-                if (!key_exists($user->_id, $logHashMap) && $daysChecked === 4) {
+                if (!key_exists($user->_id, $logHashMap) && $daysChecked === 4 && $user->role === 'standard') {
                     $profile = $profileHashMap[$user->_id];
                     if ($profile->xp - 1 == 0) {
                         $profile->banned = true;


### PR DESCRIPTION
XP inactivity deduction cron should deduct XP just from `standard` user role

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/588cc80e3e5bbe40061c06f1/tasks/58983dee3e5bbe66df30cf1c)

## Checklist
- [x] Tests covered

## Test notes

Tested with 3 users admin, accountant and standard user role. Cron deducts XP only from standard user role.