### PR TITLE
Update cron weekly stats with minimum earning stats

### DIFF
--- a/app/Helpers/WorkDays.php
+++ b/app/Helpers/WorkDays.php
@@ -11,7 +11,7 @@ use Carbon\Carbon;
 class WorkDays
 {
     /**
-     * Return list of work days (week days)
+     * Return list of work days (week days) for current month
      * Class WorkDays
      * @package App\Helpers
      */

--- a/resources/views/emails/profile/performance-report-html.blade.php
+++ b/resources/views/emails/profile/performance-report-html.blade.php
@@ -35,6 +35,13 @@
     <p>
         Real payout combined: <strong>{{$realPayoutCombined}}</strong>
     </p>
+    <p>
+        Yor expected payout for last 7 days is <strong>{{$expectedPercentage}}</strong> and your real payout is :
+        <strong>{{ $earnedPercentage }}</strong> of your role minimum : <strong>{{$roleMinimum}}</strong>.
+        Based on your performance, projection of real payout for current month is: <strong>{{$monthPrediction}}</strong>
+        and that's <strong>{{$monthPredictionPercentage}}</strong> of your role minimum.
+    </p>
+
 
     @if($xpDiff !== 0)
         <p>


### PR DESCRIPTION
Expand weekly cron stats with minimum earning stats

Data available in `ProfilePerformance` service

Show earned vs expected numbers and percentage (i.e. 78% or 132%).
Show for last week and projection for current month

Projection calculation:
average income per day for current month and multiply it with number of work days (Mon-Fri)

Note: 
Put the code for estimation in separate method of UserPerformance service

Depends on http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5873827f3e5bbe47435ea504/tasks/587b877c3e5bbe6b007f18cb

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/588cc80e3e5bbe40061c06f1/tasks/587b889f3e5bbe615b0b65d6)

## Checklist
- [x] Tests covered

## Test notes

Tested and it outputs report in email as expected.
