### PR TITLE
Fix issue with time automatic calculation for task states

### DIFF
--- a/app/Events/TaskStatusTimeCalculation.php
+++ b/app/Events/TaskStatusTimeCalculation.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Events\Event;
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class TaskStatusTimeCalculation extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * TaskStatusTimeCalculation constructor.
+     * @param GenericModel $model
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -122,7 +122,7 @@ class GenericResourceController extends Controller
             return $this->jsonError(['Insufficient permissions.'], 403);
         }
 
-        $model = GenericModel::create($fields);
+        $model = new GenericModel($fields);
 
         event(new GenericModelCreate($model));
 

--- a/app/Listeners/ProjectMembers.php
+++ b/app/Listeners/ProjectMembers.php
@@ -11,7 +11,7 @@ class ProjectMembers
 {
     const STATUS_ADDED = true;
     const STATUS_REMOVED = false;
-    
+
     /**
      * Handle the event
      * @param \App\Events\ProjectMembers $event
@@ -23,7 +23,9 @@ class ProjectMembers
         if ($project->isDirty()) {
             $oldFields = $project->getOriginal();
             $updatedFields = $project->getDirty();
-            if ($project['collection'] === 'projects' && key_exists('members', $updatedFields)) {
+            if ($project['collection'] === 'projects' && key_exists('members', $updatedFields)
+                && !empty($updatedFields['members'])
+            ) {
                 //if user is added to project send slack notification
                 foreach ($updatedFields['members'] as $newMemberId) {
                     if (!in_array($newMemberId, $oldFields['members'])) {

--- a/app/Listeners/TaskFinishedEarly.php
+++ b/app/Listeners/TaskFinishedEarly.php
@@ -27,33 +27,34 @@ class TaskFinishedEarly
                 GenericModel::setCollection('tasks');
                 $taskPerformance = $profilePerformance->perTask($task);
                 foreach ($taskPerformance as $profileId => $taskDetails) {
-                    if (key_exists('taskLastOwner', $taskDetails)) {
-                        $taskOwnerProfile = Profile::find($profileId);
-                        $mappedValues = $profilePerformance->getTaskValuesForProfile($taskOwnerProfile, $task);
+                    if (!key_exists('taskLastOwner', $taskDetails)) {
+                        continue;
+                    }
+                    $taskOwnerProfile = Profile::find($profileId);
+                    $mappedValues = $profilePerformance->getTaskValuesForProfile($taskOwnerProfile, $task);
 
-                        //calculate estimated time, working time, and 60% of estimated
-                        $estimatedSeconds = max(InputHandler::getInteger($mappedValues['estimatedHours']) * 60 * 60, 1);
-                        $secondsWorking = $taskDetails['workSeconds'];
-                        $sixtyPercentOfEstimate = 0.6 * $estimatedSeconds;
+                    //calculate estimated time, working time, and 60% of estimated
+                    $estimatedSeconds = max(InputHandler::getInteger($mappedValues['estimatedHours']) * 60 * 60, 1);
+                    $secondsWorking = $taskDetails['workSeconds'];
+                    $sixtyPercentOfEstimate = 0.6 * $estimatedSeconds;
 
-                        //if tasked finished in less than 60% of time send slack notification to admins
-                        if ($secondsWorking <= $sixtyPercentOfEstimate) {
-                            $admins = Profile::where('admin', '=', true)->get();
-                            foreach ($admins as $admin) {
-                                $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
-                                $recipient = '@' . $admin->slack;
-                                $message = 'Hey, task *'
-                                    . $task->title
-                                    . '* wrapped up in less than *60%* of estimated time. '
-                                    . $webDomain
-                                    . 'projects/'
-                                    . $task->project_id
-                                    . '/sprints/'
-                                    . $task->sprint_id
-                                    . '/tasks/'
-                                    . $task->_id;
-                                \SlackChat::message($recipient, $message);
-                            }
+                    //if tasked finished in less than 60% of time send slack notification to admins
+                    if ($secondsWorking <= $sixtyPercentOfEstimate) {
+                        $admins = Profile::where('admin', '=', true)->get();
+                        foreach ($admins as $admin) {
+                            $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
+                            $recipient = '@' . $admin->slack;
+                            $message = 'Hey, task *'
+                                . $task->title
+                                . '* wrapped up in less than *60%* of estimated time. '
+                                . $webDomain
+                                . 'projects/'
+                                . $task->project_id
+                                . '/sprints/'
+                                . $task->sprint_id
+                                . '/tasks/'
+                                . $task->_id;
+                            \SlackChat::message($recipient, $message);
                         }
                     }
                 }

--- a/app/Listeners/TaskFinishedEarly.php
+++ b/app/Listeners/TaskFinishedEarly.php
@@ -27,31 +27,33 @@ class TaskFinishedEarly
                 GenericModel::setCollection('tasks');
                 $taskPerformance = $profilePerformance->perTask($task);
                 foreach ($taskPerformance as $profileId => $taskDetails) {
-                    $taskOwnerProfile = Profile::find($profileId);
-                    $mappedValues = $profilePerformance->getTaskValuesForProfile($taskOwnerProfile, $task);
+                    if (key_exists('taskLastOwner', $taskDetails)) {
+                        $taskOwnerProfile = Profile::find($profileId);
+                        $mappedValues = $profilePerformance->getTaskValuesForProfile($taskOwnerProfile, $task);
 
-                    //calculate estimated time, working time, and 60% of estimated
-                    $estimatedSeconds = max(InputHandler::getInteger($mappedValues['estimatedHours']) * 60 * 60, 1);
-                    $secondsWorking = $taskDetails['workSeconds'];
-                    $sixtyPercentOfEstimate = 0.6 * $estimatedSeconds;
+                        //calculate estimated time, working time, and 60% of estimated
+                        $estimatedSeconds = max(InputHandler::getInteger($mappedValues['estimatedHours']) * 60 * 60, 1);
+                        $secondsWorking = $taskDetails['workSeconds'];
+                        $sixtyPercentOfEstimate = 0.6 * $estimatedSeconds;
 
-                    //if tasked finished in less than 60% of time send slack notification to admins
-                    if ($secondsWorking <= $sixtyPercentOfEstimate) {
-                        $admins = Profile::where('admin', '=', true)->get();
-                        foreach ($admins as $admin) {
-                            $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
-                            $recipient = '@' . $admin->slack;
-                            $message = 'Hey, task *'
-                                . $task->title
-                                . '* wrapped up in less than *60%* of estimated time. '
-                                . $webDomain
-                                . 'projects/'
-                                . $task->project_id
-                                . '/sprints/'
-                                . $task->sprint_id
-                                . '/tasks/'
-                                . $task->_id;
-                            \SlackChat::message($recipient, $message);
+                        //if tasked finished in less than 60% of time send slack notification to admins
+                        if ($secondsWorking <= $sixtyPercentOfEstimate) {
+                            $admins = Profile::where('admin', '=', true)->get();
+                            foreach ($admins as $admin) {
+                                $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
+                                $recipient = '@' . $admin->slack;
+                                $message = 'Hey, task *'
+                                    . $task->title
+                                    . '* wrapped up in less than *60%* of estimated time. '
+                                    . $webDomain
+                                    . 'projects/'
+                                    . $task->project_id
+                                    . '/sprints/'
+                                    . $task->sprint_id
+                                    . '/tasks/'
+                                    . $task->_id;
+                                \SlackChat::message($recipient, $message);
+                            }
                         }
                     }
                 }

--- a/app/Listeners/TaskStatusTimeCalculation.php
+++ b/app/Listeners/TaskStatusTimeCalculation.php
@@ -26,7 +26,7 @@ class TaskStatusTimeCalculation
         }
 
         //on task creation check if there is owner assigned and set work field
-        if ($task->isDirty() === false) {
+        if ($task->exists === false) {
             $task->work = [
                 $task->owner => [
                     'worked' => 0,

--- a/app/Listeners/TaskStatusTimeCalculation.php
+++ b/app/Listeners/TaskStatusTimeCalculation.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Listeners;
+
+
+class TaskStatusTimeCalculation
+{
+    /**
+     * Handle the event
+     * @param \App\Events\TaskStatusTimeCalculation $event
+     */
+    public function handle(\App\Events\TaskStatusTimeCalculation $event)
+    {
+        $task = $event->model;
+
+        if ($task['collection'] === 'tasks' && $task->isDirty()) {
+            $updatedFields = $task->getDirty();
+            $unixTime = (new \DateTime())->format('U');
+
+            //create work field when new user claimed or is assigned to task
+            if (key_exists('owner', $updatedFields) && empty($task->work)) {
+                $task->work = [
+                    $updatedFields['owner'] => [
+                        'worked' => 0,
+                        'paused' => 0,
+                        'qa' => 0,
+                        'blocked' => 0,
+                        'workTrackTimestamp' => $unixTime
+                    ]
+                ];
+            }
+            /*create new record in work field if task is reassigned and if user existed on task, push it to end of array
+            so we can know task last active user*/
+            if (key_exists('owner', $updatedFields) && !empty($task->work)) {
+                $work = $task->work;
+                if (key_exists($updatedFields['owner'], $work)) {
+                    $oldUserRecord = $work[$updatedFields['owner']];
+                    unset($work[$updatedFields['owner']]);
+                    $work[$updatedFields['owner']] = $oldUserRecord;
+                } else {
+                    $work[$updatedFields['owner']] = [
+                        'worked' => 0,
+                        'paused' => 0,
+                        'qa' => 0,
+                        'blocked' => 0,
+                        'workTrackTimestamp' => $unixTime
+                    ];
+                }
+                $task->work = $work;
+            }
+
+            //when task status is paused/resumed calculate time for worked/paused
+            if (key_exists('paused', $updatedFields) && !key_exists('submitted_for_qa', $updatedFields)) {
+                $work = $task->work;
+                $calculatedTime = (int)($unixTime - $work[$task->owner]['workTrackTimestamp']);
+                $updatedFields['paused'] === true ?
+                    $work[$task->owner]['worked'] += $calculatedTime :
+                    $work[$task->owner]['paused'] += $calculatedTime;
+                $work[$task->owner]['workTrackTimestamp'] = $unixTime;
+                $task->work = $work;
+
+            }
+
+            //when task status is blocked/unblocked calculate time for worked/blocked
+            if (key_exists('blocked', $updatedFields) && !key_exists('submitted_for_qa', $updatedFields)) {
+                $work = $task->work;
+                $calculatedTime = (int)($unixTime - $work[$task->owner]['workTrackTimestamp']);
+                $updatedFields['blocked'] === true ?
+                    $work[$task->owner]['worked'] += $calculatedTime :
+                    $work[$task->owner]['blocked'] += $calculatedTime;
+                $work[$task->owner]['workTrackTimestamp'] = $unixTime;
+                $task->work = $work;
+
+            }
+
+            //when task status is submitted_for_qa/failed_qa calculate time for worked/qa
+            if (key_exists('submitted_for_qa', $updatedFields)) {
+                $work = $task->work;
+                $calculatedTime = (int)($unixTime - $work[$task->owner]['workTrackTimestamp']);
+                $updatedFields['submitted_for_qa'] === true ?
+                    $work[$task->owner]['worked'] += $calculatedTime :
+                    $work[$task->owner]['qa'] += $calculatedTime;
+                $work[$task->owner]['workTrackTimestamp'] = $unixTime;
+                $task->work = $work;
+            }
+
+            //when task status is passed_qa calculate time for qa
+            if (key_exists('passed_qa', $updatedFields) && $updatedFields['passed_qa'] === true) {
+                $work = $task->work;
+                $calculatedTime = (int)($unixTime - $work[$task->owner]['workTrackTimestamp']);
+                $work[$task->owner]['qa'] += $calculatedTime;
+                $work[$task->owner]['workTrackTimestamp'] = $unixTime;
+                $task->work = $work;
+            }
+        }
+    }
+}

--- a/app/Listeners/TaskUpdateXP.php
+++ b/app/Listeners/TaskUpdateXP.php
@@ -28,17 +28,15 @@ class TaskUpdateXP
         GenericModel::setCollection('tasks');
 
         $taskPerformance = $profilePerformance->perTask($task);
-        $taskLastOwner = false;
 
         foreach ($taskPerformance as $profileId => $taskDetails) {
-            $taskLastOwner = false;
 
             if ($taskDetails['taskCompleted'] === false) {
                 return false;
             }
 
-            if (key_exists('taskLastOwner', $taskDetails)) {
-                $taskLastOwner = true;
+            if (!key_exists('taskLastOwner', $taskDetails)) {
+                continue;
             }
 
             $taskOwnerProfile = Profile::find($profileId);
@@ -66,79 +64,75 @@ class TaskUpdateXP
                 . $task->_id
                 . ')';
 
-            if ($taskLastOwner === true) {
-                if ($secondsWorking > 0 && $estimatedSeconds > 1) {
-                    $xpDiff = 0;
-                    $message = null;
-                    $taskXp = (float)$taskOwnerProfile->xp <= 200 ? (float)$mappedValues['xp'] : 1.0;
-                    if ($taskSpeedCoefficient < 0.75) {
-                        $xpDiff = $taskXp * $this->getDurationCoefficient($task, $taskOwnerProfile);
-                        $message = 'Early task delivery: ' . $taskLink;
-                    } elseif ($taskSpeedCoefficient > 1 && $taskSpeedCoefficient <= 1.1) {
-                        $xpDiff = -1;
-                        $message = 'Late task delivery: ' . $taskLink;
-                    } elseif ($taskSpeedCoefficient > 1.1 && $taskSpeedCoefficient <= 1.25) {
-                        $xpDiff = -2;
-                        $message = 'Late task delivery: ' . $taskLink;
-                    } elseif ($taskSpeedCoefficient > 1.25) {
-                        $xpDiff = -3;
-                        $message = 'Late task delivery: ' . $taskLink;
-                    } else {
-                        // TODO: handle properly
-                    }
+            if ($secondsWorking > 0 && $estimatedSeconds > 1) {
+                $xpDiff = 0;
+                $message = null;
+                $taskXp = (float)$taskOwnerProfile->xp <= 200 ? (float)$mappedValues['xp'] : 1.0;
+                if ($taskSpeedCoefficient < 0.75) {
+                    $xpDiff = $taskXp * $this->getDurationCoefficient($task, $taskOwnerProfile);
+                    $message = 'Early task delivery: ' . $taskLink;
+                } elseif ($taskSpeedCoefficient > 1 && $taskSpeedCoefficient <= 1.1) {
+                    $xpDiff = -1;
+                    $message = 'Late task delivery: ' . $taskLink;
+                } elseif ($taskSpeedCoefficient > 1.1 && $taskSpeedCoefficient <= 1.25) {
+                    $xpDiff = -2;
+                    $message = 'Late task delivery: ' . $taskLink;
+                } elseif ($taskSpeedCoefficient > 1.25) {
+                    $xpDiff = -3;
+                    $message = 'Late task delivery: ' . $taskLink;
+                } else {
+                    // TODO: handle properly
+                }
 
+                if ($xpDiff !== 0) {
+                    $profileXpRecord = $this->getXpRecord($taskOwnerProfile);
 
-                    if ($xpDiff !== 0) {
-                        $profileXpRecord = $this->getXpRecord($taskOwnerProfile);
+                    $records = $profileXpRecord->records;
+                    $records[] = [
+                        'xp' => $xpDiff,
+                        'details' => $message,
+                        'timestamp' => (int)((new \DateTime())->format('U') . '000') // Microtime
+                    ];
+                    $profileXpRecord->records = $records;
+                    $profileXpRecord->save();
 
-                        $records = $profileXpRecord->records;
-                        $records[] = [
-                            'xp' => $xpDiff,
-                            'details' => $message,
-                            'timestamp' => (int)((new \DateTime())->format('U') . '000') // Microtime
-                        ];
-                        $profileXpRecord->records = $records;
-                        $profileXpRecord->save();
+                    $taskOwnerProfile->xp += $xpDiff;
+                    $taskOwnerProfile->save();
 
-                        $taskOwnerProfile->xp += $xpDiff;
-                        $taskOwnerProfile->save();
+                    $this->sendSlackMessageXpUpdated($taskOwnerProfile, $task, $xpDiff);
+                }
 
-                        $this->sendSlackMessageXpUpdated($taskOwnerProfile, $task, $xpDiff);
-                    }
+                if ($taskDetails['qaSeconds'] > 24 * 60 * 60) {
+                    $poXpDiff = -3;
+                    $poMessage = 'Failed to review PR in time for ' . $taskLink;
+                } else {
+                    $poXpDiff = 0.25;
+                    $poMessage = 'Review PR in time for ' . $taskLink;
+                }
 
+                // Get project owner id
+                GenericModel::setCollection('projects');
+                $project = GenericModel::find($task->project_id);
+                $projectOwner = null;
+                if ($project) {
+                    $projectOwner = Profile::find($project->acceptedBy);
+                }
 
-                    if ($taskDetails['qaSeconds'] > 24 * 60 * 60) {
-                        $poXpDiff = -3;
-                        $poMessage = 'Failed to review PR in time for ' . $taskLink;
-                    } else {
-                        $poXpDiff = 0.25;
-                        $poMessage = 'Review PR in time for ' . $taskLink;
-                    }
+                if ($projectOwner) {
+                    $projectOwnerXpRecord = $this->getXpRecord($projectOwner);
+                    $records = $projectOwnerXpRecord->records;
+                    $records[] = [
+                        'xp' => $poXpDiff,
+                        'details' => $poMessage,
+                        'timestamp' => (int)((new \DateTime())->format('U') . '000') // Microtime
+                    ];
+                    $projectOwnerXpRecord->records = $records;
+                    $projectOwnerXpRecord->save();
 
-                    // Get project owner id
-                    GenericModel::setCollection('projects');
-                    $project = GenericModel::find($task->project_id);
-                    $projectOwner = null;
-                    if ($project) {
-                        $projectOwner = Profile::find($project->acceptedBy);
-                    }
+                    $projectOwner->xp += $poXpDiff;
+                    $projectOwner->save();
 
-                    if ($projectOwner) {
-                        $projectOwnerXpRecord = $this->getXpRecord($projectOwner);
-                        $records = $projectOwnerXpRecord->records;
-                        $records[] = [
-                            'xp' => $poXpDiff,
-                            'details' => $poMessage,
-                            'timestamp' => (int)((new \DateTime())->format('U') . '000') // Microtime
-                        ];
-                        $projectOwnerXpRecord->records = $records;
-                        $projectOwnerXpRecord->save();
-
-                        $projectOwner->xp += $poXpDiff;
-                        $projectOwner->save();
-
-                        $this->sendSlackMessageXpUpdated($projectOwner, $task, $poXpDiff);
-                    }
+                    $this->sendSlackMessageXpUpdated($projectOwner, $task, $poXpDiff);
                 }
             }
         }

--- a/app/Listeners/TaskUpdateXP.php
+++ b/app/Listeners/TaskUpdateXP.php
@@ -29,14 +29,6 @@ class TaskUpdateXP
 
         $taskPerformance = $profilePerformance->perTask($task);
 
-        // Get project owner id
-        GenericModel::setCollection('projects');
-        $project = GenericModel::find($task->project_id);
-        $projectOwner = null;
-        if ($project) {
-            $projectOwner = Profile::find($project->acceptedBy);
-        }
-
         foreach ($taskPerformance as $profileId => $taskDetails) {
             if ($taskDetails['taskCompleted'] === false) {
                 return false;
@@ -112,6 +104,14 @@ class TaskUpdateXP
             } else {
                 $poXpDiff = 0.25;
                 $poMessage = 'Review PR in time for ' . $taskLink;
+            }
+
+            // Get project owner id
+            GenericModel::setCollection('projects');
+            $project = GenericModel::find($task->project_id);
+            $projectOwner = null;
+            if ($project) {
+                $projectOwner = Profile::find($project->acceptedBy);
             }
 
             if ($projectOwner) {

--- a/app/Services/ProfilePerformance.php
+++ b/app/Services/ProfilePerformance.php
@@ -140,52 +140,48 @@ class ProfilePerformance
 
         $taskWorkHistory = is_array($task->work) ? $task->work : [];
 
-        //let's get last element from task work history array which is last task owner if task was claimed/assigned
-        $lastTaskOwnerPerformance = null;
-        foreach ($taskWorkHistory as $ownerId => $workStatus) {
-            if (!key_exists('timeRemoved', $workStatus)) {
-                $lastTaskOwnerPerformance[$ownerId] = $workStatus;
-            }
-        }
-
         // We'll respond with array of performance per task owner (if task got reassigned for example)
         $response = [];
 
         // If task was never assigned, there's no performance, respond with empty array
-        if (empty($lastTaskOwnerPerformance)) {
+        if (empty($taskWorkHistory)) {
             return $response;
         }
 
         $userPerformance = [
             'taskCompleted' => $task->passed_qa === true ? true : false
         ];
-        $taskOwner = null;
-        $workTimeTrack = null;
 
-        foreach ($lastTaskOwnerPerformance as $taskOwnerId => $stats) {
+        foreach ($taskWorkHistory as $taskOwnerId => $stats) {
             $userPerformance['workSeconds'] = $stats['worked'];
             $userPerformance['pauseSeconds'] = $stats['paused'];
             $userPerformance['qaSeconds'] = $stats['qa'];
             $userPerformance['blockedSeconds'] = $stats['blocked'];
-            $workTimeTrack = $stats['workTrackTimestamp'];
-            $taskOwner = $taskOwnerId;
-        }
 
-        // Let's just add diff based of last task state against current time if task not done yet
-        if ($userPerformance['taskCompleted'] !== true) {
-            $unixNow = (int)(new \DateTime())->format('U');
-            if ($task->paused !== true && $task->blocked !== true && $task->submitted_for_qa !== true) {
-                $userPerformance['workSeconds'] += $unixNow - $workTimeTrack;
+            // Let's just add diff based of last task state against current time if task not done yet
+            if (!key_exists('timeRemoved', $stats) && $userPerformance['taskCompleted'] !== true) {
+                $unixNow = (int)(new \DateTime())->format('U');
+                if ($task->paused !== true && $task->blocked !== true && $task->submitted_for_qa !== true) {
+                    $userPerformance['workSeconds'] += $unixNow - $stats['workTrackTimestamp'];
+                }
+                if ($task->paused) {
+                    $userPerformance['pauseSeconds'] += $unixNow - $stats['workTrackTimestamp'];
+                }
+                if ($task->submitted_for_qa) {
+                    $userPerformance['qaSeconds'] += $unixNow - $stats['workTrackTimestamp'];
+                }
             }
-            if ($task->paused) {
-                $userPerformance['pauseSeconds'] += $unixNow - $workTimeTrack;
-            }
-            if ($task->submitted_for_qa) {
-                $userPerformance['qaSeconds'] += $unixNow - $workTimeTrack;
-            }
-        }
 
-        $response[$taskOwner] = $userPerformance;
+            //set last task owner flag so we can calculate payment and XP when task is finished
+            if (!key_exists('timeRemoved', $stats)) {
+                $userPerformance['taskLastOwner'] = true;
+            }
+
+            $response[$taskOwnerId] = $userPerformance;
+
+            //remove flag from user performance array because only one user should have it
+            unset($userPerformance['taskLastOwner']);
+        }
 
         return $response;
     }

--- a/config/sharedSettings.php
+++ b/config/sharedSettings.php
@@ -58,6 +58,7 @@ return [
             'qa_ready' => 'Task ready for QA',
             'qa_fail' => 'Task failed QA',
             'qa_success' => 'Task passed QA',
+            'blocked' => 'Task is currently blocked'
         ],
         'taskComplexityOptions' => [
             1,

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -39,6 +39,9 @@ namespace {
                             ],
                             'App\Events\TaskFinishedEarly' => [
                                 'App\Listeners\TaskFinishedEarly'
+                            ]
+                            ,'App\Events\TaskStatusTimeCalculation' => [
+                                'App\Listeners\TaskStatusTimeCalculation'
                             ],
                             'App\Events\TaskStatusHistory' => [
                                 'App\Listeners\TaskStatusHistory'

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -19,7 +19,11 @@ namespace {
                     [
                         'resource' => 'tasks',
                         'event' => 'create',
-                        'listeners' => []
+                        'listeners' => [
+                            'App\Events\TaskStatusTimeCalculation' => [
+                                'App\Listeners\TaskStatusTimeCalculation'
+                            ]
+                        ]
                     ],
                     [
                         'resource' => 'tasks',
@@ -39,8 +43,8 @@ namespace {
                             ],
                             'App\Events\TaskFinishedEarly' => [
                                 'App\Listeners\TaskFinishedEarly'
-                            ]
-                            ,'App\Events\TaskStatusTimeCalculation' => [
+                            ],
+                            'App\Events\TaskStatusTimeCalculation' => [
                                 'App\Listeners\TaskStatusTimeCalculation'
                             ],
                             'App\Events\TaskStatusHistory' => [

--- a/tests/Listeners/TaskStatusTimeCalculationTest.php
+++ b/tests/Listeners/TaskStatusTimeCalculationTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Tests\Listeners;
+
+use App\Events\TaskStatusTimeCalculation;
+use App\GenericModel;
+use Tests\Collections\ProjectRelated;
+use Tests\TestCase;
+use App\Profile;
+
+class TaskStatusTimeCalculationTest extends TestCase
+{
+    use ProjectRelated;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->profile = Profile::create();
+
+        $this->profile->save();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->profile->delete();
+    }
+
+    /**
+     * Get new task without owner
+     * @return GenericModel
+     */
+    public function getNewTask()
+    {
+        GenericModel::setCollection('tasks');
+        return new GenericModel(
+            [
+                'owner' => '',
+                'paused' => false,
+                'submitted_for_qa' => false,
+                'blocked' => false,
+                'passed_qa' => false
+            ]
+        );
+    }
+
+    /**
+     * Get assigned task
+     * @return GenericModel
+     */
+    public function getAssignedTask()
+    {
+        //Assigned 5 minutes ago
+        $minutesWorking = 5;
+        $assignedAgo = (int)(new \DateTime())->sub(new \DateInterval('PT' . $minutesWorking . 'M'))->format('U');
+        GenericModel::setCollection('tasks');
+        return new GenericModel(
+            [
+                'owner' => $this->profile->id,
+                'paused' => false,
+                'submitted_for_qa' => false,
+                'blocked' => false,
+                'passed_qa' => false,
+                'work' => [
+                    $this->profile->id => [
+                        'worked' => 0,
+                        'paused' => 0,
+                        'qa' => 0,
+                        'blocked' => 0,
+                        'workTrackTimestamp' => $assignedAgo
+                    ]
+                ]
+            ]
+        );
+
+    }
+
+    /**
+     * Test task status time for task assigned
+     */
+    public function testTaskStatusTimeCalculationForTaskAssigned()
+    {
+        $task = $this->getNewTask();
+        $task->owner = $this->profile->id;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+        $task->save();
+
+        $this->assertArrayHasKey($this->profile->_id, $task['work']);
+    }
+
+    /**
+     * Test task status time for task reassigned
+     */
+    public function testTaskStatusTimeCalculationForTaskReassigned()
+    {
+
+        $task = $this->getAssignedTask();
+        $newOwner = Profile::create();
+        $task->owner = $newOwner->id;
+
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+        $task->save();
+
+        $this->assertCount(2, $task['work']);
+        $this->assertArrayHasKey($newOwner->id, $task['work']);
+    }
+
+    /**
+     * Test task status time for paused
+     */
+    public function testTaskStatusTimeCalculationForTaskPaused()
+    {
+        $task = $this->getAssignedTask();
+        $task->save();
+        $workedTimeBeforeListener = $task->work[$this->profile->id]['worked'];
+        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+
+        $task->paused = true;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+        $task->save();
+
+        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$this->profile->id]['worked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+    }
+
+    /**
+     * Test task status time for resumed
+     */
+    public function testTaskStatusTimeCalculationForTaskResumed()
+    {
+        $task = $this->getAssignedTask();
+        $task->paused = true;
+        $task->save();
+        $pausedTimeBeforeListener = $task->work[$this->profile->id]['paused'];
+        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+
+        $task->paused = false;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+        $task->save();
+
+        $this->assertGreaterThan($pausedTimeBeforeListener, $task->work[$this->profile->id]['paused']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+    }
+
+    /**
+     * Test task status time for blocked
+     */
+    public function testTaskStatusTimeCalculationForBlocked()
+    {
+        $task = $this->getAssignedTask();
+        $task->save();
+        $workedTimeBeforeListener = $task->work[$this->profile->id]['worked'];
+        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+
+        $task->blocked = true;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+        $task->save();
+
+        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$this->profile->id]['worked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+    }
+
+    /**
+     * Test task status time for unblocked
+     */
+    public function testTaskStatusTimeCalculationForUnBlocked()
+    {
+        $task = $this->getAssignedTask();
+        $task->blocked = true;
+        $task->save();
+        $blockedTimeBeforeListener = $task->work[$this->profile->id]['blocked'];
+        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+
+        $task->blocked = false;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+        $task->save();
+
+        $this->assertGreaterThan($blockedTimeBeforeListener, $task->work[$this->profile->id]['blocked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+    }
+
+    /**
+     * Test task status time for submitted for QA
+     */
+    public function testTaskStatusTimeCalculationForSubmittedForQa()
+    {
+        $task = $this->getAssignedTask();
+        $task->save();
+        $workedTimeBeforeListener = $task->work[$this->profile->id]['worked'];
+        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+
+        $task->submitted_for_qa = true;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+        $task->save();
+
+        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$this->profile->id]['worked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+    }
+
+    /**
+     * Test task status time for failed QA
+     */
+    public function testTaskStatusTimeCalculationForFailedQa()
+    {
+        $task = $this->getAssignedTask();
+        $task->submitted_for_qa = true;
+        $task->save();
+        $qaTimeBeforeListener = $task->work[$this->profile->id]['qa'];
+        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+
+        $task->submitted_for_qa = false;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+        $task->save();
+
+        $this->assertGreaterThan($qaTimeBeforeListener, $task->work[$this->profile->id]['qa']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+    }
+
+    /**
+     * Test task status time for passed QA
+     */
+    public function testTaskStatusTimeCalculationForPassedQa()
+    {
+        $task = $this->getAssignedTask();
+        $task->submitted_for_qa = true;
+        $task->save();
+        $qaTimeBeforeListener = $task->work[$this->profile->id]['qa'];
+        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+
+        $task->passed_qa = true;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+        $task->save();
+
+        $this->assertGreaterThan($qaTimeBeforeListener, $task->work[$this->profile->id]['qa']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+    }
+}

--- a/tests/Listeners/TaskStatusTimeCalculationTest.php
+++ b/tests/Listeners/TaskStatusTimeCalculationTest.php
@@ -28,6 +28,14 @@ class TaskStatusTimeCalculationTest extends TestCase
         $this->profile->delete();
     }
 
+    /*
+    |--------------------------------------------------------------------------
+    | Get methods
+    |--------------------------------------------------------------------------
+    |
+    | Here are methods to get new task, new project and new task that is assigned
+    */
+
     /**
      * Get new task without owner
      * @return GenericModel
@@ -47,13 +55,31 @@ class TaskStatusTimeCalculationTest extends TestCase
     }
 
     /**
+     * Get new project
+     * @return GenericModel
+     */
+    public function getNewProject()
+    {
+        GenericModel::setCollection('projects');
+        return new GenericModel(
+            [
+                'owner' => '',
+                'paused' => false,
+                'submitted_for_qa' => false,
+                'blocked' => false,
+                'passed_qa' => false
+            ]
+        );
+    }
+
+    /**
      * Get assigned task
      * @return GenericModel
      */
     public function getAssignedTask()
     {
         //Assigned 5 minutes ago
-        $minutesWorking = 5;
+        $minutesWorking = 30;
         $assignedAgo = (int)(new \DateTime())->sub(new \DateInterval('PT' . $minutesWorking . 'M'))->format('U');
         GenericModel::setCollection('tasks');
         return new GenericModel(
@@ -69,12 +95,70 @@ class TaskStatusTimeCalculationTest extends TestCase
                         'paused' => 0,
                         'qa' => 0,
                         'blocked' => 0,
-                        'workTrackTimestamp' => $assignedAgo
+                        'workTrackTimestamp' => $assignedAgo,
+                        'timeAssigned' => $assignedAgo
                     ]
                 ]
             ]
         );
 
+    }
+
+    /*
+    |--------------------------------------------------------------------------
+    | Test methods
+    |--------------------------------------------------------------------------
+    |
+    | Here are methods to test TaskStatusTimeCalculation listener in different cases
+    */
+
+    /**
+     * Test task status time for model with wrong collection
+     */
+    public function testTaskStatusTimeWrongCollection()
+    {
+        $project = $this->getNewProject();
+        $event = new TaskStatusTimeCalculation($project);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $out = $listener->handle($event);
+        $this->assertEquals(false, $out);
+    }
+
+    /**
+     * Test task status time for new task without owner
+     */
+    public function testTaskStatusTimeNewTaskWithoutOwner()
+    {
+        $task = $this->getNewTask();
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $out = $listener->handle($event);
+        $this->assertEquals(false, $out);
+    }
+
+    /**
+     * Test task status time with new task that has owner
+     */
+    public function teskTastStatusTimeNewTaskWithOwner()
+    {
+        $task = $this->getNewTask();
+        $task->owner = $this->profile;
+        $task->save();
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+
+        $this->assertArrayHasKey('worked', $task->work[$task->owner]);
+        $this->assertArrayHasKey('paused', $task->work[$task->owner]);
+        $this->assertArrayHasKey('qa', $task->work[$task->owner]);
+        $this->assertArrayHasKey('workTrackTimestamp', $task->work[$task->owner]);
+        $this->assertArrayHasKey('timeAssigned', $task->work[$task->owner]);
+        $this->assertEquals(0, $task->work[$task->owner]['worked']);
+        $this->assertEquals(0, $task->work[$task->owner]['paused']);
+        $this->assertEquals(0, $task->work[$task->owner]['qa']);
+        $this->assertEquals(0, $task->work[$task->owner]['blocked']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'],
+            $task->work[$task->owner]['timeAssigned']);
     }
 
     /**
@@ -89,7 +173,17 @@ class TaskStatusTimeCalculationTest extends TestCase
         $listener->handle($event);
         $task->save();
 
-        $this->assertArrayHasKey($this->profile->_id, $task['work']);
+        $this->assertArrayHasKey('worked', $task->work[$task->owner]);
+        $this->assertArrayHasKey('paused', $task->work[$task->owner]);
+        $this->assertArrayHasKey('qa', $task->work[$task->owner]);
+        $this->assertArrayHasKey('workTrackTimestamp', $task->work[$task->owner]);
+        $this->assertArrayHasKey('timeAssigned', $task->work[$task->owner]);
+        $this->assertEquals(0, $task->work[$task->owner]['worked']);
+        $this->assertEquals(0, $task->work[$task->owner]['paused']);
+        $this->assertEquals(0, $task->work[$task->owner]['qa']);
+        $this->assertEquals(0, $task->work[$task->owner]['blocked']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'],
+            $task->work[$task->owner]['timeAssigned']);
     }
 
     /**
@@ -99,6 +193,8 @@ class TaskStatusTimeCalculationTest extends TestCase
     {
 
         $task = $this->getAssignedTask();
+        $oldOwner = $task->owner;
+        $oldWorkTrackTimestamp = $task->work[$oldOwner]['workTrackTimestamp'];
         $newOwner = Profile::create();
         $task->owner = $newOwner->id;
 
@@ -107,8 +203,36 @@ class TaskStatusTimeCalculationTest extends TestCase
         $listener->handle($event);
         $task->save();
 
-        $this->assertCount(2, $task['work']);
-        $this->assertArrayHasKey($newOwner->id, $task['work']);
+        $this->assertCount(2, $task->work);
+        $this->assertArrayHasKey($newOwner->id, $task->work);
+
+        $this->assertArrayHasKey('worked', $task->work[$oldOwner]);
+        $this->assertArrayHasKey('paused', $task->work[$oldOwner]);
+        $this->assertArrayHasKey('qa', $task->work[$oldOwner]);
+        $this->assertArrayHasKey('workTrackTimestamp', $task->work[$oldOwner]);
+        $this->assertArrayHasKey('timeAssigned', $task->work[$oldOwner]);
+        $this->assertArrayHasKey('timeRemoved', $task->work[$oldOwner]);
+        $this->assertEquals($task->work[$oldOwner]['workTrackTimestamp'] - $oldWorkTrackTimestamp,
+            $task->work[$oldOwner]['worked']);
+        $this->assertEquals(0, $task->work[$oldOwner]['paused']);
+        $this->assertEquals(0, $task->work[$oldOwner]['qa']);
+        $this->assertEquals(0, $task->work[$oldOwner]['blocked']);
+        $this->assertEquals($task->work[$oldOwner]['workTrackTimestamp'],
+            $task->work[$oldOwner]['timeRemoved']);
+
+        $this->assertArrayHasKey('worked', $task->work[$task->owner]);
+        $this->assertArrayHasKey('paused', $task->work[$task->owner]);
+        $this->assertArrayHasKey('qa', $task->work[$task->owner]);
+        $this->assertArrayHasKey('workTrackTimestamp', $task->work[$task->owner]);
+        $this->assertArrayHasKey('timeAssigned', $task->work[$task->owner]);
+        $this->assertArrayNotHasKey('timeRemoved', $task->work[$task->owner]);
+        $this->assertEquals(0, $task->work[$task->owner]['worked']);
+        $this->assertEquals(0, $task->work[$task->owner]['paused']);
+        $this->assertEquals(0, $task->work[$task->owner]['qa']);
+        $this->assertEquals(0, $task->work[$task->owner]['blocked']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'],
+            $task->work[$task->owner]['timeAssigned']);
+
     }
 
     /**
@@ -118,8 +242,8 @@ class TaskStatusTimeCalculationTest extends TestCase
     {
         $task = $this->getAssignedTask();
         $task->save();
-        $workedTimeBeforeListener = $task->work[$this->profile->id]['worked'];
-        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+        $workedTimeBeforeListener = $task->work[$task->owner]['worked'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
 
         $task->paused = true;
         $event = new TaskStatusTimeCalculation($task);
@@ -127,8 +251,10 @@ class TaskStatusTimeCalculationTest extends TestCase
         $listener->handle($event);
         $task->save();
 
-        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$this->profile->id]['worked']);
-        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$task->owner]['worked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener,
+            $task->work[$task->owner]['worked']);
     }
 
     /**
@@ -139,8 +265,8 @@ class TaskStatusTimeCalculationTest extends TestCase
         $task = $this->getAssignedTask();
         $task->paused = true;
         $task->save();
-        $pausedTimeBeforeListener = $task->work[$this->profile->id]['paused'];
-        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+        $pausedTimeBeforeListener = $task->work[$task->owner]['paused'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
 
         $task->paused = false;
         $event = new TaskStatusTimeCalculation($task);
@@ -148,8 +274,10 @@ class TaskStatusTimeCalculationTest extends TestCase
         $listener->handle($event);
         $task->save();
 
-        $this->assertGreaterThan($pausedTimeBeforeListener, $task->work[$this->profile->id]['paused']);
-        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+        $this->assertGreaterThan($pausedTimeBeforeListener, $task->work[$task->owner]['paused']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener,
+            $task->work[$task->owner]['paused']);
     }
 
     /**
@@ -159,8 +287,8 @@ class TaskStatusTimeCalculationTest extends TestCase
     {
         $task = $this->getAssignedTask();
         $task->save();
-        $workedTimeBeforeListener = $task->work[$this->profile->id]['worked'];
-        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+        $workedTimeBeforeListener = $task->work[$task->owner]['worked'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
 
         $task->blocked = true;
         $event = new TaskStatusTimeCalculation($task);
@@ -168,8 +296,10 @@ class TaskStatusTimeCalculationTest extends TestCase
         $listener->handle($event);
         $task->save();
 
-        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$this->profile->id]['worked']);
-        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$task->owner]['worked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener,
+            $task->work[$task->owner]['worked']);
     }
 
     /**
@@ -180,8 +310,8 @@ class TaskStatusTimeCalculationTest extends TestCase
         $task = $this->getAssignedTask();
         $task->blocked = true;
         $task->save();
-        $blockedTimeBeforeListener = $task->work[$this->profile->id]['blocked'];
-        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+        $blockedTimeBeforeListener = $task->work[$task->owner]['blocked'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
 
         $task->blocked = false;
         $event = new TaskStatusTimeCalculation($task);
@@ -189,8 +319,10 @@ class TaskStatusTimeCalculationTest extends TestCase
         $listener->handle($event);
         $task->save();
 
-        $this->assertGreaterThan($blockedTimeBeforeListener, $task->work[$this->profile->id]['blocked']);
-        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+        $this->assertGreaterThan($blockedTimeBeforeListener, $task->work[$task->owner]['blocked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener,
+            $task->work[$task->owner]['blocked']);
     }
 
     /**
@@ -200,8 +332,8 @@ class TaskStatusTimeCalculationTest extends TestCase
     {
         $task = $this->getAssignedTask();
         $task->save();
-        $workedTimeBeforeListener = $task->work[$this->profile->id]['worked'];
-        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+        $workedTimeBeforeListener = $task->work[$task->owner]['worked'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
 
         $task->submitted_for_qa = true;
         $event = new TaskStatusTimeCalculation($task);
@@ -209,8 +341,10 @@ class TaskStatusTimeCalculationTest extends TestCase
         $listener->handle($event);
         $task->save();
 
-        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$this->profile->id]['worked']);
-        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$task->owner]['worked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener,
+            $task->work[$task->owner]['worked']);
     }
 
     /**
@@ -221,8 +355,8 @@ class TaskStatusTimeCalculationTest extends TestCase
         $task = $this->getAssignedTask();
         $task->submitted_for_qa = true;
         $task->save();
-        $qaTimeBeforeListener = $task->work[$this->profile->id]['qa'];
-        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+        $qaTimeBeforeListener = $task->work[$task->owner]['qa'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
 
         $task->submitted_for_qa = false;
         $event = new TaskStatusTimeCalculation($task);
@@ -230,8 +364,10 @@ class TaskStatusTimeCalculationTest extends TestCase
         $listener->handle($event);
         $task->save();
 
-        $this->assertGreaterThan($qaTimeBeforeListener, $task->work[$this->profile->id]['qa']);
-        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+        $this->assertGreaterThan($qaTimeBeforeListener, $task->work[$task->owner]['qa']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener,
+            $task->work[$task->owner]['qa']);
     }
 
     /**
@@ -242,8 +378,8 @@ class TaskStatusTimeCalculationTest extends TestCase
         $task = $this->getAssignedTask();
         $task->submitted_for_qa = true;
         $task->save();
-        $qaTimeBeforeListener = $task->work[$this->profile->id]['qa'];
-        $timeStampBeforeListener = $task->work[$this->profile->id]['workTrackTimestamp'];
+        $qaTimeBeforeListener = $task->work[$task->owner]['qa'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
 
         $task->passed_qa = true;
         $event = new TaskStatusTimeCalculation($task);
@@ -251,7 +387,200 @@ class TaskStatusTimeCalculationTest extends TestCase
         $listener->handle($event);
         $task->save();
 
-        $this->assertGreaterThan($qaTimeBeforeListener, $task->work[$this->profile->id]['qa']);
-        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$this->profile->id]['workTrackTimestamp']);
+        $this->assertGreaterThan($qaTimeBeforeListener, $task->work[$task->owner]['qa']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener,
+            $task->work[$task->owner]['qa']);
+
+    }
+
+    /**
+     * Test task status time calculation complex flow (Reassigned, paused, blocked, qa, fail qa and finally done)
+     */
+    public function testTaskStatusTimeComplexFlowTaskDone()
+    {
+        //user that assigned task after 5 mins pause task
+        $task = $this->getAssignedTask();
+        $task->save();
+        $workedTimeBeforeListener = $task->work[$task->owner]['worked'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
+
+        $task->paused = true;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+
+
+        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$task->owner]['worked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener,
+            $task->work[$task->owner]['worked']);
+
+        $modifyTimeStamp = $task->work;
+        $modifyTimeStamp[$task->owner]['workTrackTimestamp'] = (new \DateTime())->format('U') - 20 * 60;
+        $task->work = $modifyTimeStamp;
+        $task->save();
+        //task resumed
+        $pausedTimeBeforeListener = $task->work[$task->owner]['paused'];
+        $timeStampBeforeResumed = $task->work[$task->owner]['workTrackTimestamp'];
+
+        $task->paused = false;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+
+
+        $this->assertGreaterThan($pausedTimeBeforeListener, $task->work[$task->owner]['paused']);
+        $this->assertGreaterThan($timeStampBeforeResumed, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals(($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeResumed),
+            $task->work[$task->owner]['paused']);
+
+        $modifyTimeStamp = $task->work;
+        $modifyTimeStamp[$task->owner]['workTrackTimestamp'] = (new \DateTime())->format('U') - 15 * 60;
+        $task->work = $modifyTimeStamp;
+        $task->save();
+
+        //task reassigned
+        $oldOwner = $task->owner;
+        $oldWorkTrackTimestamp = $task->work[$oldOwner]['workTrackTimestamp'];
+        $oldWorked = $task->work[$oldOwner]['worked'];
+        $oldWorkPaused = $task->work[$oldOwner]['paused'];
+        $oldWorkQa = $task->work[$oldOwner]['qa'];
+        $oldWorkBlocked = $task->work[$oldOwner]['blocked'];
+        $newOwner = Profile::create();
+        $task->owner = $newOwner->id;
+
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+
+        $this->assertCount(2, $task->work);
+        $this->assertArrayHasKey($newOwner->id, $task->work);
+
+        $this->assertArrayHasKey('worked', $task->work[$oldOwner]);
+        $this->assertArrayHasKey('paused', $task->work[$oldOwner]);
+        $this->assertArrayHasKey('qa', $task->work[$oldOwner]);
+        $this->assertArrayHasKey('workTrackTimestamp', $task->work[$oldOwner]);
+        $this->assertArrayHasKey('timeAssigned', $task->work[$oldOwner]);
+        $this->assertArrayHasKey('timeRemoved', $task->work[$oldOwner]);
+        $this->assertEquals($task->work[$oldOwner]['workTrackTimestamp'] - $oldWorkTrackTimestamp + $oldWorked,
+            $task->work[$oldOwner]['worked']);
+        $this->assertEquals($oldWorkPaused, $task->work[$oldOwner]['paused']);
+        $this->assertEquals($oldWorkQa, $task->work[$oldOwner]['qa']);
+        $this->assertEquals($oldWorkBlocked, $task->work[$oldOwner]['blocked']);
+        $this->assertEquals($task->work[$oldOwner]['workTrackTimestamp'],
+            $task->work[$oldOwner]['timeRemoved']);
+
+        $this->assertArrayHasKey('worked', $task->work[$task->owner]);
+        $this->assertArrayHasKey('paused', $task->work[$task->owner]);
+        $this->assertArrayHasKey('qa', $task->work[$task->owner]);
+        $this->assertArrayHasKey('workTrackTimestamp', $task->work[$task->owner]);
+        $this->assertArrayHasKey('timeAssigned', $task->work[$task->owner]);
+        $this->assertArrayNotHasKey('timeRemoved', $task->work[$task->owner]);
+        $this->assertEquals(0, $task->work[$task->owner]['worked']);
+        $this->assertEquals(0, $task->work[$task->owner]['paused']);
+        $this->assertEquals(0, $task->work[$task->owner]['qa']);
+        $this->assertEquals(0, $task->work[$task->owner]['blocked']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'],
+            $task->work[$task->owner]['timeAssigned']);
+
+        $modifyTimeStamp = $task->work;
+        $modifyTimeStamp[$task->owner]['workTrackTimestamp'] = (new \DateTime())->format('U') - 13 * 60;
+        $modifyTimeStamp[$task->owner]['assignedTime'] = (new \DateTime())->format('U') - 13 * 60;
+        $task->work = $modifyTimeStamp;
+        $task->save();
+
+        //qa ready
+        $workedTimeBeforeListener = $task->work[$task->owner]['worked'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
+
+        $task->submitted_for_qa = true;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+
+        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$task->owner]['worked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener,
+            $task->work[$task->owner]['worked']);
+
+        $modifyTimeStamp = $task->work;
+        $modifyTimeStamp[$task->owner]['workTrackTimestamp'] = (new \DateTime())->format('U') - 11 * 60;
+        $task->work = $modifyTimeStamp;
+        $task->save();
+
+        //qa failed
+        $qaTimeBeforeListener = $task->work[$task->owner]['qa'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
+
+        $task->submitted_for_qa = false;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+
+        $this->assertGreaterThan($qaTimeBeforeListener, $task->work[$task->owner]['qa']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener,
+            $task->work[$task->owner]['qa']);
+
+        $modifyTimeStamp = $task->work;
+        $modifyTimeStamp[$task->owner]['workTrackTimestamp'] = (new \DateTime())->format('U') - 9 * 60;
+        $task->work = $modifyTimeStamp;
+        $task->paused = true;
+        $task->save();
+
+        //task resumed
+
+        $pausedTimeBeforeListener = $task->work[$task->owner]['paused'];
+        $timeStampBeforeResumed = $task->work[$task->owner]['workTrackTimestamp'];
+
+        $task->paused = false;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+
+
+        $this->assertGreaterThan($pausedTimeBeforeListener, $task->work[$task->owner]['paused']);
+        $this->assertGreaterThan($timeStampBeforeResumed, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals(($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeResumed),
+            $task->work[$task->owner]['paused']);
+
+        $modifyTimeStamp = $task->work;
+        $modifyTimeStamp[$task->owner]['workTrackTimestamp'] = (new \DateTime())->format('U') - 7 * 60;
+        $task->work = $modifyTimeStamp;
+        $task->save();
+
+        //task submitted for qa again
+        $workedTimeBeforeListener = $task->work[$task->owner]['worked'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
+
+        $task->submitted_for_qa = true;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+
+        $this->assertGreaterThan($workedTimeBeforeListener, $task->work[$task->owner]['worked']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener
+            + $workedTimeBeforeListener, $task->work[$task->owner]['worked']);
+
+        $modifyTimeStamp = $task->work;
+        $modifyTimeStamp[$task->owner]['workTrackTimestamp'] = (new \DateTime())->format('U') - 5 * 60;
+        $task->work = $modifyTimeStamp;
+        $task->save();
+
+        //finally QA passed
+        $qaTimeBeforeListener = $task->work[$task->owner]['qa'];
+        $timeStampBeforeListener = $task->work[$task->owner]['workTrackTimestamp'];
+
+        $task->passed_qa = true;
+        $event = new TaskStatusTimeCalculation($task);
+        $listener = new \App\Listeners\TaskStatusTimeCalculation();
+        $listener->handle($event);
+
+        $this->assertGreaterThan($qaTimeBeforeListener, $task->work[$task->owner]['qa']);
+        $this->assertGreaterThan($timeStampBeforeListener, $task->work[$task->owner]['workTrackTimestamp']);
+        $this->assertEquals($task->work[$task->owner]['workTrackTimestamp'] - $timeStampBeforeListener
+            + $qaTimeBeforeListener, $task->work[$task->owner]['qa']);
     }
 }


### PR DESCRIPTION
Fix issue with automatic time calculation for task states update

write new field on top of tasks in format of:
`work`: [ 
`userId`: [
        `worked`: integer, 
        `paused`: integer,
                `qa`: integer,
        `blocked`: integer
             ]
   ]
Update XP update listener to account for new structure


[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/5898b9da3e5bbe32a5176b7f/tasks/5890786d3e5bbe47e216a5f2)

## Checklist

- [x] Tests covered

## Test notes

Tested all kind of variations per task status (claimed, assigned, reassigned, paused, resumed, qa, failed qa, blocked, unblocked, passed qa). Everything working as expected. Xp per profile updated properly, xp history record also, admin xp record + xp record history also. Written test unit for listener. Because profileperformance is changed, unit tests should be also updated, have that in mind. 