### PR TITLE
Added support for archiving models with generic resource controller

### DIFF
--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -19,7 +19,8 @@ class GenericResourceController extends Controller
      */
     public function index(Request $request)
     {
-        $this->getArchivedCollection($request);
+        //if request route is archive, set archived collection for query
+        $this->checkArchivedCollection($request);
 
         $query = GenericModel::query();
 
@@ -226,7 +227,11 @@ class GenericResourceController extends Controller
         return $this->jsonError('Issue with archiving resource.');
     }
 
-    private function getArchivedCollection(Request $request)
+    /**
+     * @param Request $request
+     * @return bool|Request
+     */
+    private function checkArchivedCollection(Request $request)
     {
         $URI = $request->path();
 

--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -233,9 +233,9 @@ class GenericResourceController extends Controller
      */
     private function checkArchivedCollection(Request $request)
     {
-        $URI = $request->path();
+        $uri = $request->path();
 
-        if (strpos($URI,'/archive')) {
+        if (strpos($uri,'/archive')) {
             GenericModel::setCollection($request->route('resource') . '_archived');
 
             return $request;

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -64,14 +64,17 @@ Route::group(['prefix' => 'api/v1/app/{appName}', 'middleware' => ['multiple-app
          * Generic resources routes
          *
          * All of routes use `the-shop.genericResource` middleware so that GenericModel gets injected
-         * `$collection` from `resource` route paramter
+         * `$collection` from `resource` route parameter
          */
         Route::get('{resource}', 'GenericResourceController@index')->middleware(['the-shop.genericResource', 'adapters']);
+        Route::get('{resource}/archive', 'GenericResourceController@index')->middleware(['the-shop.genericResource', 'adapters']);
+        Route::put('{resource}/{id}/archive', 'GenericResourceController@archive')->middleware(['the-shop.genericResource', 'adapters']);
         Route::get('{resource}/{id}', 'GenericResourceController@show')->middleware(['the-shop.genericResource', 'adapters']);
         Route::post('{resource}', 'GenericResourceController@store')->middleware(['the-shop.genericResource', 'adapters']);
         Route::put('{resource}/{id}', 'GenericResourceController@update')->middleware(['the-shop.genericResource', 'adapters']);
         Route::delete('{resource}/{id}', 'GenericResourceController@destroy')->middleware(['the-shop.genericResource', 'adapters']);
         Route::post('{resource}/register', 'GenericResourceController@store')->middleware(['the-shop.genericResource', 'adapters']);
+
     });
 });
 


### PR DESCRIPTION
Implement `archive` functionality on GenericResourceController

`PUT /<resourceName>/<id>/archive` without any payload. Store the document with `id` to "`resourceName`_archived" collection and then delete it from the `resourceName` collection

`GET /<resourceName>/archive` should return a list of archived documents (read from `_archived` collection) - support filtering, sort, etc. as on standard get route

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/589f2a323e5bbe20af5c56e6/tasks/58a17d733e5bbe7d257fe567)

## Checklist
- [x] Tests covered

## Test notes

Tested on projects and tasks. PUT route clones requested model and save it to 'resourceName_archived' collection, after that deletes model from origin collection. GET route gets all models from 'resourceName_archived' collection.