### PR TITLE
GenericResourceController to move deleted files to deleted collection

### DIFF
--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -194,9 +194,9 @@ class GenericResourceController extends Controller
 
         if ($deletedModel->save()) {
             $model->delete();
-            return $model;
+            return $deletedModel;
         }
-        
+
         return $this->jsonError('Issue with deleting resource.');
     }
 }

--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -178,6 +178,7 @@ class GenericResourceController extends Controller
     public function destroy(Request $request)
     {
         $model = GenericModel::find($request->route('id'));
+        $modelCollection = GenericModel::getCollection();
 
         if (!$model instanceof GenericModel) {
             return $this->jsonError(['Model not found.'], 404);
@@ -188,9 +189,14 @@ class GenericResourceController extends Controller
             return $this->jsonError(['Insufficient permissions.'], 403);
         }
 
-        if ($model->delete()) {
+        $deletedModel = $model->replicate();
+        $deletedModel['collection'] = $modelCollection . '_deleted';
+
+        if ($deletedModel->save()) {
+            $model->delete();
             return $model;
         }
+        
         return $this->jsonError('Issue with deleting resource.');
     }
 }


### PR DESCRIPTION
GenericResource::delete() to move document to deleted documents collection

I.e. if collection was called `projects`, save the document to `projects_deleted` collection and then delete it from the original collection.

Make sure that it works in that exact order

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/589f2a323e5bbe20af5c56e6/tasks/589f289e3e5bbe20b463b55f)

## Checklist

- [x] Tests covered

Controller clones existing model, and after that model is saved to 'resourceName_deleted' collection it removes old model from origin collection.