### PR TITLE
Listener to delete sprints and tasks on project deletion

### DIFF
--- a/app/Events/GenericModelDelete.php
+++ b/app/Events/GenericModelDelete.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Events\Event;
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class GenericModelDelete extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * GenericModelDelete constructor.
+     * @param GenericModel $model
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model= $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Events/ProjectDelete.php
+++ b/app/Events/ProjectDelete.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use App\Events\Event;
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class ProjectDelete extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * ProjectDelete constructor.
+     * @param GenericModel $model
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Events\GenericModelCreate;
+use App\Events\GenericModelDelete;
 use App\Events\GenericModelUpdate;
 use App\GenericModel;
 use Illuminate\Http\Request;
@@ -196,6 +197,7 @@ class GenericResourceController extends Controller
         $deletedModel['collection'] = $modelCollection . '_deleted';
 
         if ($deletedModel->save()) {
+            event(new GenericModelDelete($model));
             $model->delete();
             return $deletedModel;
         }

--- a/app/Listeners/GenericModelDelete.php
+++ b/app/Listeners/GenericModelDelete.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Traits\DynamicListener;
+
+class GenericModelDelete
+{
+    use DynamicListener;
+
+    /**
+     * Handle the event.
+     * @param \App\Events\GenericModelDelete $event
+     */
+    public function handle(\App\Events\GenericModelDelete $event)
+    {
+        $action = 'delete';
+        $this->triggerListeners($event, $action);
+    }
+}

--- a/app/Listeners/ProjectDelete.php
+++ b/app/Listeners/ProjectDelete.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Listeners;
+
+use App\GenericModel;
+
+class ProjectDelete
+{
+    /**
+     * Handle the event.
+     * @param \App\Events\ProjectDelete $event
+     */
+    public function handle(\App\Events\ProjectDelete $event)
+    {
+        $project = $event->model;
+
+        $preSetCollection = GenericModel::getCollection();
+        //delete all project sprints
+        GenericModel::setCollection('sprints');
+            $projectSprints = GenericModel::where('project_id', '=', $project->id)->get();
+        foreach ($projectSprints as $sprint) {
+            $deletedSprint = $sprint->replicate();
+            $deletedSprint['collection'] = 'sprints_deleted';
+            if ($deletedSprint->save()) {
+                $sprint->delete();
+            }
+        }
+        //delete all project tasks
+        GenericModel::setCollection('tasks');
+        $projectTasks = GenericModel::where('project_id', '=', $project->id)->get();
+        foreach ($projectTasks as $task) {
+            $deletedTask = $task->replicate();
+            $deletedTask['collection'] = 'tasks_deleted';
+            if ($deletedTask->save()) {
+                $task->delete();
+            }
+        }
+        GenericModel::setCollection($preSetCollection);
+    }
+}

--- a/app/Providers/TheShopEventServiceProvider.php
+++ b/app/Providers/TheShopEventServiceProvider.php
@@ -19,9 +19,12 @@ class TheShopEventServiceProvider extends ServiceProvider
         'App\Events\GenericModelUpdate' => [
             'App\Listeners\GenericModelUpdate'
         ],
+        'App\Events\GenericModelDelete' => [
+            'App\Listeners\GenericModelDelete'
+        ],
         'App\Events\ProfileUpdate' => [
             'App\Listeners\ProfileUpdate'
-        ]
+        ],
     ];
 
     /**

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -64,6 +64,15 @@ namespace {
                             ]
                         ]
                     ],
+                    [
+                        'resource' => 'projects',
+                        'event' => 'delete',
+                        'listeners' => [
+                            'App\Events\ProjectDelete' => [
+                                'App\Listeners\ProjectDelete'
+                            ]
+                        ]
+                    ]
                 ]
             );
         }


### PR DESCRIPTION
Project delete listener implementation

To delete sprints and tasks upon project deletion.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/589f2a323e5bbe20af5c56e6/tasks/589f282f3e5bbe20b222a5dd)

## Checklist

- [x] Tests covered

## Test notes

Upon deletion of project listener triggers and deletes it's sprints and tasks.