### PR TITLE
Fixed loose search on generic resource controller

### DIFF
--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -39,7 +39,8 @@ class GenericResourceController extends Controller
                 'orderBy',
                 'orderDirection',
                 'offset',
-                'limit'
+                'limit',
+                'looseSearch'
             ];
 
             $operator = '=';


### PR DESCRIPTION
Investigate (and fix) why `looseSearch` is not working on generic resource controller

Task description if aplicable

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/589f2a323e5bbe20af5c56e6/tasks/589f305e3e5bbe20b463b581)

## Checklist

- [x] Tests covered

## Test notes

Problem was that looseSearch should be in $skipParams array to exclude that parameter from searching.