### PR TITLE
Output XP award for users above 200xp

### DIFF
--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -27,6 +27,10 @@ class Task implements AdaptersInterface
 
         $mappedValues = $profilePerformance->getTaskValuesForProfile($profile, $this->task);
 
+        if ($mappedValues['xp'] === 0) {
+            $mappedValues['xp'] = $profilePerformance->getDurationCoefficient($this->task, $profile);
+        }
+
         $originalEstimate = $this->task->estimatedHours;
 
         foreach ($mappedValues as $key => $value) {

--- a/app/Listeners/TaskUpdateXP.php
+++ b/app/Listeners/TaskUpdateXP.php
@@ -67,9 +67,9 @@ class TaskUpdateXP
             if ($secondsWorking > 0 && $estimatedSeconds > 1) {
                 $xpDiff = 0;
                 $message = null;
-                $taskXp = (float)$taskOwnerProfile->xp <= 200 ? (float)$mappedValues['xp'] : 1.0;
+                $taskXp = (float) $taskOwnerProfile->xp <= 200 ? (float) $mappedValues['xp'] : 1.0;
                 if ($taskSpeedCoefficient < 0.75) {
-                    $xpDiff = $taskXp * $this->getDurationCoefficient($task, $taskOwnerProfile);
+                    $xpDiff = $taskXp * $profilePerformance->getDurationCoefficient($task, $taskOwnerProfile);
                     $message = 'Early task delivery: ' . $taskLink;
                 } elseif ($taskSpeedCoefficient > 1 && $taskSpeedCoefficient <= 1.1) {
                     $xpDiff = -1;
@@ -91,7 +91,7 @@ class TaskUpdateXP
                     $records[] = [
                         'xp' => $xpDiff,
                         'details' => $message,
-                        'timestamp' => (int)((new \DateTime())->format('U') . '000') // Microtime
+                        'timestamp' => (int) ((new \DateTime())->format('U') . '000') // Microtime
                     ];
                     $profileXpRecord->records = $records;
                     $profileXpRecord->save();
@@ -124,7 +124,7 @@ class TaskUpdateXP
                     $records[] = [
                         'xp' => $poXpDiff,
                         'details' => $poMessage,
-                        'timestamp' => (int)((new \DateTime())->format('U') . '000') // Microtime
+                        'timestamp' => (int) ((new \DateTime())->format('U') . '000') // Microtime
                     ];
                     $projectOwnerXpRecord->records = $records;
                     $projectOwnerXpRecord->save();
@@ -158,36 +158,6 @@ class TaskUpdateXP
         GenericModel::setCollection($oldCollection);
 
         return $profileXp;
-    }
-
-    /**
-     * @param GenericModel $task
-     * @param Profile $taskOwner
-     * @return float|int
-     */
-    private function getDurationCoefficient(GenericModel $task, Profile $taskOwner)
-    {
-        $profilePerformance = new ProfilePerformance();
-        $mappedValues = $profilePerformance->getTaskValuesForProfile($taskOwner, $task);
-
-        $profileCoefficient = 0.9;
-        if ((float)$taskOwner->xp > 200 && (float)$taskOwner->xp <= 400) {
-            $profileCoefficient = 0.8;
-        } elseif ((float)$taskOwner->xp > 400 && (float)$taskOwner->xp <= 600) {
-            $profileCoefficient = 0.6;
-        } elseif ((float)$taskOwner->xp > 600 && (float)$taskOwner->xp <= 800) {
-            $profileCoefficient = 0.4;
-        } elseif ((float)$taskOwner->xp > 800 && (float)$taskOwner->xp <= 1000) {
-            $profileCoefficient = 0.2;
-        } elseif ((float)$taskOwner->xp > 1000) {
-            $profileCoefficient = 0.1;
-        }
-
-        if ((int)$mappedValues['estimatedHours'] < 10) {
-            return ((int)$mappedValues['estimatedHours'] / 10) * $profileCoefficient;
-        }
-
-        return $profileCoefficient;
     }
 
     /**

--- a/app/Services/ProfilePerformance.php
+++ b/app/Services/ProfilePerformance.php
@@ -217,6 +217,35 @@ class ProfilePerformance
     }
 
     /**
+     * @param GenericModel $task
+     * @param Profile $taskOwner
+     * @return float|int
+     */
+    public function getDurationCoefficient(GenericModel $task, Profile $taskOwner)
+    {
+        $mappedValues = $this->getTaskValuesForProfile($taskOwner, $task);
+
+        $profileCoefficient = 0.9;
+        if ((float)$taskOwner->xp > 200 && (float)$taskOwner->xp <= 400) {
+            $profileCoefficient = 0.8;
+        } elseif ((float)$taskOwner->xp > 400 && (float)$taskOwner->xp <= 600) {
+            $profileCoefficient = 0.6;
+        } elseif ((float)$taskOwner->xp > 600 && (float)$taskOwner->xp <= 800) {
+            $profileCoefficient = 0.4;
+        } elseif ((float)$taskOwner->xp > 800 && (float)$taskOwner->xp <= 1000) {
+            $profileCoefficient = 0.2;
+        } elseif ((float)$taskOwner->xp > 1000) {
+            $profileCoefficient = 0.1;
+        }
+
+        if ((int)$mappedValues['estimatedHours'] < 10) {
+            return ((int)$mappedValues['estimatedHours'] / 10) * $profileCoefficient;
+        }
+
+        return $profileCoefficient;
+    }
+
+    /**
      * Calculates salary based on performance in time range
      *
      * @param array $aggregated


### PR DESCRIPTION
Calculate XP award and output in task adapter for users with 200+ XP

Extract logic to `ProfilePerformance` service if not there already

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/589f2a323e5bbe20af5c56e6/tasks/589993ae3e5bbe32a5176bb4)

## Checklist

- [x] Tests covered

## Test notes
Adapter returns calculated XP award for users above 200xp. Upon finishing tasks xp update works like it should.