### PR TITLE
Added support on profile performance to output 0 payout if noPayout field is set on task

### DIFF
--- a/app/Services/ProfilePerformance.php
+++ b/app/Services/ProfilePerformance.php
@@ -230,6 +230,9 @@ class ProfilePerformance
         $out = [];
         $out['xp'] = $xpAward;
         $out['payout'] = InputHandler::getFloat($hourlyRate) * $task->estimatedHours;
+        if (isset($task->noPayout) && $task->noPayout === true) {
+            $out['payout'] = 0;
+        }
         $out['estimatedHours'] = $estimatedHours;
 
         return $out;


### PR DESCRIPTION
if there's field `noPayout` on the task, task performance should return `0` as the `payout`

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/589f2a323e5bbe20af5c56e6/tasks/589c35de3e5bbe44f640df84)

## Checklist

- [x] Tests covered

## Test notes

For now create a new task. Look at his payout output, and then go to DB add field noPayout = true to task and watch output again. It will return 0 payout. Then change noPayout = false. It will return aggregated payout.

