### PR TITLE
Isolated and refactored delete logic from GenericResourceController to GenericModel

### DIFF
--- a/app/GenericModel.php
+++ b/app/GenericModel.php
@@ -90,4 +90,23 @@ class GenericModel extends StarModel
         }
         return $this;
     }
+
+    /**
+     * GenericModel to delete model and pass it to _deleted collection
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    public function delete()
+    {
+        $preSetCollection = self::getCollection();
+        $deletedModel = $this->replicate();
+        self::setCollection($this->collection . '_deleted');
+        $deletedModel->collection = self::$collectionName;
+        $deletedModel->_id = $this->original['_id'];
+
+        if ($deletedModel->save()) {
+            parent::delete();
+            self::setCollection($preSetCollection);
+            return $deletedModel;
+        }
+    }
 }

--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -191,7 +191,6 @@ class GenericResourceController extends Controller
     public function destroy(Request $request)
     {
         $model = GenericModel::find($request->route('id'));
-        $modelCollection = GenericModel::getCollection();
 
         if (!$model instanceof GenericModel) {
             return $this->jsonError(['Model not found.'], 404);
@@ -202,12 +201,9 @@ class GenericResourceController extends Controller
             return $this->jsonError(['Insufficient permissions.'], 403);
         }
 
-        $deletedModel = $model->replicate();
-        $deletedModel['collection'] = $modelCollection . '_deleted';
-
-        if ($deletedModel->save()) {
+        $deletedModel = $model->delete();
+        if ($deletedModel) {
             event(new GenericModelDelete($model));
-            $model->delete();
             return $deletedModel;
         }
 

--- a/tests/GenericModel/GenericModelTest.php
+++ b/tests/GenericModel/GenericModelTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\GenericModel;
+
+use Tests\Collections\ProjectRelated;
+use Tests\TestCase;
+use App\GenericModel;
+
+class GenericModelTest extends TestCase
+{
+    use ProjectRelated;
+
+    /**
+     * Test GenericModel delete
+     */
+    public function testGenericModelDelete()
+    {
+        $project = $this->getNewProject();
+        $project->save();
+
+        $projectId = $project->id;
+        $project->delete();
+
+        GenericModel::setCollection('projects');
+        $oldProject = GenericModel::find($projectId);
+
+        GenericModel::setCollection('projects_deleted');
+        $foundDeletedProject = GenericModel::find($projectId);
+
+        $this->assertEquals($projectId, $foundDeletedProject->id);
+        $this->assertEquals(null, $oldProject);
+    }
+}


### PR DESCRIPTION
Refactor logic for model move to  `_deleted` collection - move it to GenericModel::delete()

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/589f2a323e5bbe20af5c56e6/tasks/58a340a93e5bbe144e1eca97)

## Checklist
- [x] Tests covered

## Test notes

Try to create project for example. Then delete him. Project will be deleted and moved to projects_deleted collection with same attributes as before just collection changed.