### PR TITLE
Feature/deduct xp award based on task priority

### DIFF
--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -27,6 +27,11 @@ class Task implements AdaptersInterface
 
         $mappedValues = $profilePerformance->getTaskValuesForProfile($profile, $this->task);
 
+        if ($mappedValues['xp'] === 0) {
+            $mappedValues['xp'] = $profilePerformance->getDurationCoefficient($this->task, $profile) *
+            $profilePerformance->taskPriorityCoefficient($profile, $this->task);
+        }
+
         $originalEstimate = $this->task->estimatedHours;
 
         foreach ($mappedValues as $key => $value) {

--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -27,10 +27,6 @@ class Task implements AdaptersInterface
 
         $mappedValues = $profilePerformance->getTaskValuesForProfile($profile, $this->task);
 
-        if ($mappedValues['xp'] === 0) {
-            $mappedValues['xp'] = $profilePerformance->getDurationCoefficient($this->task, $profile);
-        }
-
         $originalEstimate = $this->task->estimatedHours;
 
         foreach ($mappedValues as $key => $value) {

--- a/app/Listeners/TaskUpdateXP.php
+++ b/app/Listeners/TaskUpdateXP.php
@@ -67,10 +67,10 @@ class TaskUpdateXP
             if ($secondsWorking > 0 && $estimatedSeconds > 1) {
                 $xpDiff = 0;
                 $message = null;
-                $taskXp = (float) $taskOwnerProfile->xp <= 200 ? (float) $mappedValues['xp'] : 1.0;
+                $taskXp = (float) $mappedValues['xp'];
                 if ($taskSpeedCoefficient < 0.75) {
-                    $xpDiff = $taskXp * $profilePerformance->getDurationCoefficient($task, $taskOwnerProfile)
-                    * $this->taskPriorityCoefficient($taskOwnerProfile, $task);
+                    $xpDiff = $taskOwnerProfile->xp <= 200 ?
+                        $taskXp * $profilePerformance->getDurationCoefficient($task, $taskOwnerProfile) : $taskXp;
                     $message = 'Early task delivery: ' . $taskLink;
                 } elseif ($taskSpeedCoefficient > 1 && $taskSpeedCoefficient <= 1.1) {
                     $xpDiff = -1;
@@ -185,51 +185,5 @@ class TaskUpdateXP
             . $task->_id
             . ')';
         Slack::sendMessage($recipient, $slackMessage, Slack::HIGH_PRIORITY);
-    }
-
-    /**
-     * Calculate task priority coefficient
-     * @param Profile $taskOwner
-     * @param GenericModel $task
-     * @return float|int
-     */
-    private function taskPriorityCoefficient(Profile $taskOwner, GenericModel $task)
-    {
-        $taskPriorityCoefficient = 1;
-
-        //get all projects that user is a member of
-        $preSetcollection = GenericModel::getCollection();
-        GenericModel::setCollection('projects');
-        $taskOwnerprojects = GenericModel::whereIn('members', [$taskOwner->id])
-            ->get();
-
-        GenericModel::setCollection('tasks');
-
-        $unassignedTasksPriority = [];
-
-        //get all unassigned tasks from projects that user is a member of, and make list of tasks priority
-        foreach ($taskOwnerprojects as $project) {
-            $projectTasks = GenericModel::where('project_id', '=', $project->id)
-                ->get();
-            foreach ($projectTasks as $projectTask) {
-                if (empty($projectTask->owner) && !in_array($projectTask->priority, $unassignedTasksPriority)) {
-                    $unassignedTasksPriority[$projectTask->id] = $projectTask->priority;
-                }
-            }
-        }
-
-        //check task priority and compare with list of unassigned tasks priority and set task priority coefficient
-        if ($task->priority === 'Low'
-            && (in_array('Medium', $unassignedTasksPriority) || in_array('High', $unassignedTasksPriority))) {
-            $taskPriorityCoefficient = 0.5;
-        }
-
-        if ($task->priority === 'Medium' && in_array('High', $unassignedTasksPriority)) {
-            $taskPriorityCoefficient = 0.8;
-        }
-
-        GenericModel::setCollection($preSetcollection);
-
-        return $taskPriorityCoefficient;
     }
 }

--- a/app/Listeners/TaskUpdateXP.php
+++ b/app/Listeners/TaskUpdateXP.php
@@ -67,10 +67,12 @@ class TaskUpdateXP
             if ($secondsWorking > 0 && $estimatedSeconds > 1) {
                 $xpDiff = 0;
                 $message = null;
-                $taskXp = (float) $mappedValues['xp'];
+                $taskXp = (float) $taskOwnerProfile->xp <= 200 ? (float) $mappedValues['xp'] : 1.0;
                 if ($taskSpeedCoefficient < 0.75) {
                     $xpDiff = $taskOwnerProfile->xp <= 200 ?
-                        $taskXp * $profilePerformance->getDurationCoefficient($task, $taskOwnerProfile) : $taskXp;
+                        $taskXp * $profilePerformance->getDurationCoefficient($task, $taskOwnerProfile)
+                    : $profilePerformance->getDurationCoefficient($task, $taskOwnerProfile) *
+                        $profilePerformance->taskPriorityCoefficient($taskOwnerProfile, $task);
                     $message = 'Early task delivery: ' . $taskLink;
                 } elseif ($taskSpeedCoefficient > 1 && $taskSpeedCoefficient <= 1.1) {
                     $xpDiff = -1;

--- a/app/Services/ProfilePerformance.php
+++ b/app/Services/ProfilePerformance.php
@@ -223,7 +223,9 @@ class ProfilePerformance
         $estimatedHours = (float)$task->estimatedHours * 1000 / min($xp, 1000);
 
         // Award xp based on complexity
-        $xpAward = $xp <= 200 ? $taskComplexity * $estimatedHours * 10 / $xp : 0;
+        $xpAward = $xp <= 200 ? ($taskComplexity * $estimatedHours * 10 / $xp) *
+            $this->taskPriorityCoefficient($profile, $task)
+            : $this->getDurationCoefficient($task, $profile) * $this->taskPriorityCoefficient($profile, $task);
 
         $hourlyRate = Config::get('sharedSettings.internalConfiguration.hourlyRate');
 
@@ -262,6 +264,52 @@ class ProfilePerformance
         }
 
         return $profileCoefficient;
+    }
+
+    /**
+     * Calculate task priority coefficient
+     * @param Profile $taskOwner
+     * @param GenericModel $task
+     * @return float|int
+     */
+    private function taskPriorityCoefficient(Profile $taskOwner, GenericModel $task)
+    {
+        $taskPriorityCoefficient = 1;
+
+        //get all projects that user is a member of
+        $preSetcollection = GenericModel::getCollection();
+        GenericModel::setCollection('projects');
+        $taskOwnerprojects = GenericModel::whereIn('members', [$taskOwner->id])
+            ->get();
+
+        GenericModel::setCollection('tasks');
+
+        $unassignedTasksPriority = [];
+
+        //get all unassigned tasks from projects that user is a member of, and make list of tasks priority
+        foreach ($taskOwnerprojects as $project) {
+            $projectTasks = GenericModel::where('project_id', '=', $project->id)
+                ->get();
+            foreach ($projectTasks as $projectTask) {
+                if (empty($projectTask->owner) && !in_array($projectTask->priority, $unassignedTasksPriority)) {
+                    $unassignedTasksPriority[$projectTask->id] = $projectTask->priority;
+                }
+            }
+        }
+
+        //check task priority and compare with list of unassigned tasks priority and set task priority coefficient
+        if ($task->priority === 'Low'
+            && (in_array('Medium', $unassignedTasksPriority) || in_array('High', $unassignedTasksPriority))) {
+            $taskPriorityCoefficient = 0.5;
+        }
+
+        if ($task->priority === 'Medium' && in_array('High', $unassignedTasksPriority)) {
+            $taskPriorityCoefficient = 0.8;
+        }
+
+        GenericModel::setCollection($preSetcollection);
+
+        return $taskPriorityCoefficient;
     }
 
     /**

--- a/app/Services/ProfilePerformance.php
+++ b/app/Services/ProfilePerformance.php
@@ -223,9 +223,8 @@ class ProfilePerformance
         $estimatedHours = (float)$task->estimatedHours * 1000 / min($xp, 1000);
 
         // Award xp based on complexity
-        $xpAward = $xp <= 200 ? ($taskComplexity * $estimatedHours * 10 / $xp) *
-            $this->taskPriorityCoefficient($profile, $task)
-            : $this->getDurationCoefficient($task, $profile) * $this->taskPriorityCoefficient($profile, $task);
+        $xpAward = $xp <= 200 ? $taskComplexity * $estimatedHours * 10 / $xp *
+            $this->taskPriorityCoefficient($profile, $task) : 0;
 
         $hourlyRate = Config::get('sharedSettings.internalConfiguration.hourlyRate');
 
@@ -272,7 +271,7 @@ class ProfilePerformance
      * @param GenericModel $task
      * @return float|int
      */
-    private function taskPriorityCoefficient(Profile $taskOwner, GenericModel $task)
+    public function taskPriorityCoefficient(Profile $taskOwner, GenericModel $task)
     {
         $taskPriorityCoefficient = 1;
 

--- a/tests/Collections/ProjectRelated.php
+++ b/tests/Collections/ProjectRelated.php
@@ -51,7 +51,8 @@ trait ProjectRelated
                 'paused' => false,
                 'submitted_for_qa' => false,
                 'blocked' => false,
-                'passed_qa' => false
+                'passed_qa' => false,
+                'members' => []
             ]
         );
     }

--- a/tests/Listeners/TaskUpdateXpTest.php
+++ b/tests/Listeners/TaskUpdateXpTest.php
@@ -265,4 +265,270 @@ class TaskUpdateXpTest extends TestCase
         $this->assertEquals(197.2025, $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
+
+    /**
+     * Test task update XP with low priority task without any high or medium priority unassigned tasks and with
+     * other low priority task
+     */
+    public function testTaskUpdateXpTaskPriorityOnlyLow()
+    {
+        $project = $this->getNewProject();
+        $members = $project->members;
+        $members[] = $this->profile->id;
+        $project->members = $members;
+        $project->save();
+
+        $taskLowPriorityWithoutOwner = $this->getNewTask();
+        $taskLowPriorityWithoutOwner->project_id = $project->id;
+        $taskLowPriorityWithoutOwner->priority = 'Low';
+        $taskLowPriorityWithoutOwner->save();
+
+
+        // Assigned 30 minutes ago
+        $minutesWorking = 30;
+        $assignedAgo = (int) (new \DateTime())->sub(new \DateInterval('PT' . $minutesWorking . 'M'))->format('U');
+
+        $taskLowPriority = $this->getAssignedTask($assignedAgo);
+        $taskLowPriority->priority = 'Low';
+        $taskLowPriority->estimatedHours = 0.6;
+        $taskLowPriority->complexity = 5;
+        $taskLowPriority->project_id = $project->id;
+        $taskLowPriority->save();
+
+        $taskLowPriority->submitted_for_qa = true;
+        $worked = $taskLowPriority->work;
+
+        //qa was 10 mins
+        $worked[$taskLowPriority->owner]['qa'] = 10 * 60;
+
+        //task worked 15 mins
+        $worked[$taskLowPriority->owner]['worked'] = 15 * 60;
+
+        $taskLowPriority->work = $worked;
+        $taskLowPriority->save();
+        $taskLowPriority->passed_qa = true;
+
+        $event = new ModelUpdate($taskLowPriority);
+        $listener = new TaskUpdateXP($taskLowPriority);
+        $out = $listener->handle($event);
+
+        $checkXpProfile = Profile::find($this->profile->id);
+        $this->assertEquals(200.2025, $checkXpProfile->xp);
+        $this->assertEquals(true, $out);
+    }
+
+    /**
+     * Test task deduct Xp award for low priority task because there are medium and high priority unassigned tasks
+     */
+    public function testTaskUpdateXpTaskPriorityLowDeduct()
+    {
+        $project = $this->getNewProject();
+        $members = $project->members;
+        $members[] = $this->profile->id;
+        $project->members = $members;
+        $project->save();
+
+        $taskMediumPriorityWithoutOwner = $this->getNewTask();
+        $taskMediumPriorityWithoutOwner->project_id = $project->id;
+        $taskMediumPriorityWithoutOwner->priority = 'Medium';
+        $taskMediumPriorityWithoutOwner->save();
+
+        $taskHighPriorityWithoutOwner = $this->getNewTask();
+        $taskHighPriorityWithoutOwner->project_id = $project->id;
+        $taskHighPriorityWithoutOwner->priority = 'High';
+        $taskHighPriorityWithoutOwner->save();
+
+        // Assigned 30 minutes ago
+        $minutesWorking = 30;
+        $assignedAgo = (int) (new \DateTime())->sub(new \DateInterval('PT' . $minutesWorking . 'M'))->format('U');
+
+        $taskLowPriority = $this->getAssignedTask($assignedAgo);
+        $taskLowPriority->priority = 'Low';
+        $taskLowPriority->estimatedHours = 0.6;
+        $taskLowPriority->complexity = 5;
+        $taskLowPriority->project_id = $project->id;
+        $taskLowPriority->save();
+
+        $taskLowPriority->submitted_for_qa = true;
+        $worked = $taskLowPriority->work;
+
+        //qa was 10 mins
+        $worked[$taskLowPriority->owner]['qa'] = 10 * 60;
+
+        //task worked 15 mins
+        $worked[$taskLowPriority->owner]['worked'] = 15 * 60;
+
+        $taskLowPriority->work = $worked;
+        $taskLowPriority->save();
+        $taskLowPriority->passed_qa = true;
+
+        $event = new ModelUpdate($taskLowPriority);
+        $listener = new TaskUpdateXP($taskLowPriority);
+        $out = $listener->handle($event);
+
+        $checkXpProfile = Profile::find($this->profile->id);
+        $this->assertEquals(200.10125, $checkXpProfile->xp);
+        $this->assertEquals(true, $out);
+    }
+
+    /**
+     * Test task update XP with medium priorty task, without any unassigned high priority and with unassigned low
+     * priority task
+     */
+    public function testTaskUpdateXpTaskPriorityMediumOrLow()
+    {
+        $project = $this->getNewProject();
+        $members = $project->members;
+        $members[] = $this->profile->id;
+        $project->members = $members;
+        $project->save();
+
+        $taskLowPriorityWithoutOwner = $this->getNewTask();
+        $taskLowPriorityWithoutOwner->project_id = $project->id;
+        $taskLowPriorityWithoutOwner->priority = 'Low';
+        $taskLowPriorityWithoutOwner->save();
+
+
+        // Assigned 30 minutes ago
+        $minutesWorking = 30;
+        $assignedAgo = (int) (new \DateTime())->sub(new \DateInterval('PT' . $minutesWorking . 'M'))->format('U');
+
+        $taskMediumPriority = $this->getAssignedTask($assignedAgo);
+        $taskMediumPriority->priority = 'Medium';
+        $taskMediumPriority->estimatedHours = 0.6;
+        $taskMediumPriority->complexity = 5;
+        $taskMediumPriority->project_id = $project->id;
+        $taskMediumPriority->save();
+
+        $taskMediumPriority->submitted_for_qa = true;
+        $worked = $taskMediumPriority->work;
+
+        //qa was 10 mins
+        $worked[$taskMediumPriority->owner]['qa'] = 10 * 60;
+
+        //task worked 15 mins
+        $worked[$taskMediumPriority->owner]['worked'] = 15 * 60;
+
+        $taskMediumPriority->work = $worked;
+        $taskMediumPriority->save();
+        $taskMediumPriority->passed_qa = true;
+
+        $event = new ModelUpdate($taskMediumPriority);
+        $listener = new TaskUpdateXP($taskMediumPriority);
+        $out = $listener->handle($event);
+
+        $checkXpProfile = Profile::find($this->profile->id);
+        $this->assertEquals(200.2025, $checkXpProfile->xp);
+        $this->assertEquals(true, $out);
+    }
+
+    /**
+     * Test task deduct XP award for medium priorty task because there is unassigned high priority task
+     */
+    public function testTaskUpdateXpTaskPriorityMediumDeduct()
+    {
+        $project = $this->getNewProject();
+        $members = $project->members;
+        $members[] = $this->profile->id;
+        $project->members = $members;
+        $project->save();
+
+        $taskHighPriorityWithoutOwner = $this->getNewTask();
+        $taskHighPriorityWithoutOwner->project_id = $project->id;
+        $taskHighPriorityWithoutOwner->priority = 'High';
+        $taskHighPriorityWithoutOwner->save();
+
+        $taskMediumPriorityWithoutOwner = $this->getNewTask();
+        $taskMediumPriorityWithoutOwner->project_id = $project->id;
+        $taskMediumPriorityWithoutOwner->priority = 'Medium';
+        $taskMediumPriorityWithoutOwner->save();
+
+
+        // Assigned 30 minutes ago
+        $minutesWorking = 30;
+        $assignedAgo = (int) (new \DateTime())->sub(new \DateInterval('PT' . $minutesWorking . 'M'))->format('U');
+
+        $taskMediumPriority = $this->getAssignedTask($assignedAgo);
+        $taskMediumPriority->priority = 'Medium';
+        $taskMediumPriority->estimatedHours = 0.6;
+        $taskMediumPriority->complexity = 5;
+        $taskMediumPriority->project_id = $project->id;
+        $taskMediumPriority->save();
+
+        $taskMediumPriority->submitted_for_qa = true;
+        $worked = $taskMediumPriority->work;
+
+        //qa was 10 mins
+        $worked[$taskMediumPriority->owner]['qa'] = 10 * 60;
+
+        //task worked 15 mins
+        $worked[$taskMediumPriority->owner]['worked'] = 15 * 60;
+
+        $taskMediumPriority->work = $worked;
+        $taskMediumPriority->save();
+        $taskMediumPriority->passed_qa = true;
+
+        $event = new ModelUpdate($taskMediumPriority);
+        $listener = new TaskUpdateXP($taskMediumPriority);
+        $out = $listener->handle($event);
+
+        $checkXpProfile = Profile::find($this->profile->id);
+        $this->assertEquals(200.162, $checkXpProfile->xp);
+        $this->assertEquals(true, $out);
+    }
+
+    /**
+     * Test task update XP with high priority task
+     */
+    public function testTaskUpdateXpTaskPriorityHigh()
+    {
+        $project = $this->getNewProject();
+        $members = $project->members;
+        $members[] = $this->profile->id;
+        $project->members = $members;
+        $project->save();
+
+        $taskHighPriorityWithoutOwner = $this->getNewTask();
+        $taskHighPriorityWithoutOwner->project_id = $project->id;
+        $taskHighPriorityWithoutOwner->priority = 'High';
+        $taskHighPriorityWithoutOwner->save();
+
+        $taskMediumPriorityWithoutOwner = $this->getNewTask();
+        $taskMediumPriorityWithoutOwner->project_id = $project->id;
+        $taskMediumPriorityWithoutOwner->priority = 'Medium';
+        $taskMediumPriorityWithoutOwner->save();
+
+
+        // Assigned 30 minutes ago
+        $minutesWorking = 30;
+        $assignedAgo = (int) (new \DateTime())->sub(new \DateInterval('PT' . $minutesWorking . 'M'))->format('U');
+
+        $taskHighPriority = $this->getAssignedTask($assignedAgo);
+        $taskHighPriority->priority = 'High';
+        $taskHighPriority->estimatedHours = 0.6;
+        $taskHighPriority->complexity = 5;
+        $taskHighPriority->project_id = $project->id;
+        $taskHighPriority->save();
+
+        $taskHighPriority->submitted_for_qa = true;
+        $worked = $taskHighPriority->work;
+
+        //qa was 10 mins
+        $worked[$taskHighPriority->owner]['qa'] = 10 * 60;
+
+        //task worked 15 mins
+        $worked[$taskHighPriority->owner]['worked'] = 15 * 60;
+
+        $taskHighPriority->work = $worked;
+        $taskHighPriority->save();
+        $taskHighPriority->passed_qa = true;
+
+        $event = new ModelUpdate($taskHighPriority);
+        $listener = new TaskUpdateXP($taskHighPriority);
+        $out = $listener->handle($event);
+
+        $checkXpProfile = Profile::find($this->profile->id);
+        $this->assertEquals(200.2025, $checkXpProfile->xp);
+        $this->assertEquals(true, $out);
+    }
 }


### PR DESCRIPTION
Deduct XP award based on task priority

Coefficient 1.0 for high priority
Coefficient 0.8 for normal priority or 1.0 if there's no high priority tasks on user projects
Coefficient 0.5 for low priority or 1.0 if there's no higher priority tasks on user projects

Covered with unit tests.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/589f2a323e5bbe20af5c56e6/tasks/58a576803e5bbe4077351602)

## Checklist
- [x] Tests covered

## Test notes

Create few tasks some with high priority, some with medium, and few with low. Try to claim any of tasks and check your XP award upon finishing in time (passed_qa). 