### PR TITLE
Added generic resource restore route, updated project delete listener, covered with unit tests

### DIFF
--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -204,11 +204,40 @@ class GenericResourceController extends Controller
 
         $deletedModel = $model->delete();
         if ($deletedModel) {
-            event(new GenericModelDelete($model));
+            event(new GenericModelDelete($deletedModel));
             return $deletedModel;
         }
 
         return $this->jsonError('Issue with deleting resource.');
+    }
+
+    /**
+     * @param Request $request
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function restore(Request $request)
+    {
+        $modelCollection = GenericModel::getCollection();
+
+        GenericModel::setCollection($modelCollection . '_deleted');
+        $model = GenericModel::find($request->route('id'));
+
+        if (!$model instanceof GenericModel) {
+            return $this->jsonError(['Model not found.'], 404);
+        }
+
+        $fields = $request->all();
+        if ($this->validateInputsForResource($fields, $request->route('resource'), $model) === false) {
+            return $this->jsonError(['Insufficient permissions.'], 403);
+        }
+
+        $restoredModel = $model->restore();
+        if ($restoredModel) {
+            event(new GenericModelDelete($restoredModel));
+            return $restoredModel;
+        }
+
+        return $this->jsonError('Issue with unarchiving resource.');
     }
 
     /**

--- a/app/Http/Controllers/GenericResourceController.php
+++ b/app/Http/Controllers/GenericResourceController.php
@@ -237,7 +237,7 @@ class GenericResourceController extends Controller
             return $restoredModel;
         }
 
-        return $this->jsonError('Issue with unarchiving resource.');
+        return $this->jsonError('Issue with restoring resource.');
     }
 
     /**

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -74,6 +74,7 @@ Route::group(['prefix' => 'api/v1/app/{appName}', 'middleware' => ['multiple-app
         Route::post('{resource}', 'GenericResourceController@store')->middleware(['the-shop.genericResource', 'adapters']);
         Route::put('{resource}/{id}', 'GenericResourceController@update')->middleware(['the-shop.genericResource', 'adapters']);
         Route::delete('{resource}/{id}', 'GenericResourceController@destroy')->middleware(['the-shop.genericResource', 'adapters']);
+        Route::put('{resource}/{id}/restore', 'GenericResourceController@restore')->middleware(['the-shop.genericResource', 'adapters']);
         Route::post('{resource}/register', 'GenericResourceController@store')->middleware(['the-shop.genericResource', 'adapters']);
     });
 });

--- a/app/Listeners/ProjectDelete.php
+++ b/app/Listeners/ProjectDelete.php
@@ -14,27 +14,28 @@ class ProjectDelete
     {
         $project = $event->model;
 
-        $preSetCollection = GenericModel::getCollection();
-        //delete all project sprints
-        GenericModel::setCollection('sprints');
-            $projectSprints = GenericModel::where('project_id', '=', $project->id)->get();
+        //check if project is deleted or restored to get all sprints from proper collection
+        $project['collection'] === 'projects_deleted' ?
+            GenericModel::setCollection('sprints')
+            : GenericModel::setCollection('sprints_deleted');
+
+        $projectSprints = GenericModel::where('project_id', '=', $project->id)->get();
+
+        //delete or restore project sprints
         foreach ($projectSprints as $sprint) {
-            $deletedSprint = $sprint->replicate();
-            $deletedSprint['collection'] = 'sprints_deleted';
-            if ($deletedSprint->save()) {
-                $sprint->delete();
-            }
+            $project['collection'] === 'projects_deleted' ? $sprint->delete() : $sprint->restore();
         }
-        //delete all project tasks
-        GenericModel::setCollection('tasks');
+
+        //check if project is deleted or restored to get all tasks from proper collection
+        $project['collection'] === 'projects_deleted' ?
+            GenericModel::setCollection('tasks')
+            : GenericModel::setCollection('tasks_deleted');
+
         $projectTasks = GenericModel::where('project_id', '=', $project->id)->get();
+
+        //delete or restore project tasks
         foreach ($projectTasks as $task) {
-            $deletedTask = $task->replicate();
-            $deletedTask['collection'] = 'tasks_deleted';
-            if ($deletedTask->save()) {
-                $task->delete();
-            }
+            $project['collection'] === 'projects_deleted' ? $task->delete() : $task->restore();
         }
-        GenericModel::setCollection($preSetCollection);
     }
 }

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -74,6 +74,15 @@ namespace {
                         ]
                     ],
                     [
+                        'resource' => 'projects_deleted',
+                        'event' => 'delete',
+                        'listeners' => [
+                            'App\Events\ProjectDelete' => [
+                                'App\Listeners\ProjectDelete'
+                            ]
+                        ]
+                    ],
+                    [
                         'resource' => 'projects',
                         'event' => 'archive',
                         'listeners' => [

--- a/tests/Collections/ProjectRelated.php
+++ b/tests/Collections/ProjectRelated.php
@@ -76,6 +76,24 @@ trait ProjectRelated
     }
 
     /**
+     * Get new deleted project
+     * @return GenericModel
+     */
+    public function getNewDeletedProject()
+    {
+        GenericModel::setCollection('projects_deleted');
+        return new GenericModel(
+            [
+                'owner' => '',
+                'paused' => false,
+                'submitted_for_qa' => false,
+                'blocked' => false,
+                'passed_qa' => false
+            ]
+        );
+    }
+
+    /**
      * Get assigned task
      * @return GenericModel
      */

--- a/tests/GenericModel/GenericModelTest.php
+++ b/tests/GenericModel/GenericModelTest.php
@@ -97,4 +97,50 @@ class GenericModelTest extends TestCase
         $this->assertEquals($projectId, $foundDeletedProject->id);
         $this->assertEquals(null, $oldProject);
     }
+
+    /**
+     * Test model unArchive with wrong collection - exception error
+     */
+    public function testGenericModelDeleteWrongCollection()
+    {
+        $project = $this->getNewDeletedProject();
+        $project->save();
+
+        $this->setExpectedException('Exception', 'Model collection now allowed to delete', 403);
+        $project->delete();
+    }
+
+    /**
+     * Test model unArchive
+     */
+    public function testGenericModelRestore()
+    {
+        $project = $this->getNewDeletedProject();
+        $project->save();
+
+        $deletedProjectId = $project->id;
+
+        $project->restore();
+
+        GenericModel::setCollection('projects_deleted');
+        $deletedProject = GenericModel::find($deletedProjectId);
+
+        GenericModel::setCollection('projects');
+        $foundRestoredProject = GenericModel::find($deletedProjectId);
+
+        $this->assertEquals($deletedProjectId, $foundRestoredProject->id);
+        $this->assertEquals(null, $deletedProject);
+    }
+
+    /**
+     * Test model unArchive with wrong collection - exception error
+     */
+    public function testGenericModelRestoreWrongCollection()
+    {
+        $project = $this->getNewProject();
+        $project->save();
+
+        $this->setExpectedException('Exception', 'Model collection now allowed to restore', 403);
+        $project->restore();
+    }
 }


### PR DESCRIPTION
Implement  `<resource>/<id>/restore` route

Should do the opposite of the `/delete` route.
Covered delete / restore functionality with unit tests for GenericResource model.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58a95bdb3e5bbe572360d586/tasks/58a6d4343e5bbe40773516d0)

## Checklist
- [x] Seeders written
- [x] Tests covered

## Test notes

Create one project for example, and then try to do <DELETE>  /projects/{id} . After that do <PUT> /projects/{id}/restore. First it will delete origin document and move it to projects_deleted collection. On restore it deletes document from _deleted collection and move it back to origin. Also u can try to create project with few sprints and tasks. Listener will delete all sprints and tasks when project deleted and it will restore them also when project restored. **U should seed database again because listener-rules seeder is updated.**