### PR TITLE
Refactor xp award and deduct logic

### DIFF
--- a/app/Console/Commands/NotifyAdminsTaskDeadline.php
+++ b/app/Console/Commands/NotifyAdminsTaskDeadline.php
@@ -22,7 +22,7 @@ class NotifyAdminsTaskDeadline extends Command
      *
      * @var string
      */
-    protected $description = 'Ping admins / PO on slack about approaching task deadline 2 days before deadline';
+    protected $description = 'Ping admins / PO on slack about approaching task deadline 7 days before deadline';
 
     /**
      * Execute the console command.
@@ -35,10 +35,10 @@ class NotifyAdminsTaskDeadline extends Command
         $tasks = GenericModel::all();
 
         $unixDateNow = (new \DateTime())->format('U');
-        $unixTwoDaysFromNow = $unixDateNow + 48 * 60 * 60;
-        $twoDaysFromNowDate = \DateTime::createFromFormat('U', $unixTwoDaysFromNow)->format('Y-m-d');
+        $unixSevenDaysFromNow = (int) ($unixDateNow) + 24 * 7 * 60 * 60;
+        $sevenDaysFromNowDate = \DateTime::createFromFormat('U', $unixSevenDaysFromNow)->format('Y-m-d');
         foreach ($tasks as $task) {
-            if (!empty($task->due_date) && $twoDaysFromNowDate
+            if (!empty($task->due_date) && $sevenDaysFromNowDate
                 === \DateTime::createFromFormat('U', InputHandler::getUnixTimestamp($task->due_date))->format('Y-m-d')
             ) {
                 GenericModel::setCollection('projects');
@@ -56,7 +56,7 @@ class NotifyAdminsTaskDeadline extends Command
                             . $task->title
                             . '* on project *'
                             . $taskProject->name
-                            . '* deadline is in *2 days* '
+                            . '* deadline is in *7 days* '
                             . '(*'
                             . $taskDueDate
                             . '*)';

--- a/app/Console/Commands/NotifyAdminsTaskPriority.php
+++ b/app/Console/Commands/NotifyAdminsTaskPriority.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\GenericModel;
+use Carbon\Carbon;
+use App\Profile;
+use App\Helpers\InputHandler;
+use App\Helpers\Slack;
+
+class NotifyAdminsTaskPriority extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ping:admins:task:priority';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Notify admins and Pos on slack about task priority deadlines.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $preSetCollection = GenericModel::getCollection();
+        GenericModel::setCollection('tasks');
+
+        $tasks = GenericModel::all();
+        $unixTimeNow = Carbon::now()->format('U');
+        $unixTime2Days = Carbon::now()->addDays(2)->format('U');
+        $unixTime7Days = Carbon::now()->addDays(7)->format('U');
+        $unixTime14Days = Carbon::now()->addDays(14)->format('U');
+        $unixTime28Days = Carbon::now()->addDays(28)->format('U');
+
+        $tasksDueDateNextTwoDays = [];
+        $tasksDueDates = [];
+
+        foreach ($tasks as $task) {
+            if (empty($task->owner)) {
+                $taskDueDate = InputHandler::getUnixTimestamp($task->due_date);
+                //get task if task priority is High and due_date is in next 2 days
+                if ($taskDueDate >= $unixTimeNow && $taskDueDate <= $unixTime2Days && $task->priority === 'High') {
+                    $tasksDueDateNextTwoDays[$task->project_id][] = $task;
+                }
+
+                //check if task priority is High and due_date is between next 2-7 days, add counter
+                if ($taskDueDate > $unixTime2Days && $taskDueDate <= $unixTime7Days && $task->priority === 'High') {
+                    if (!key_exists($task->project_id, $tasksDueDates)) {
+                        $tasksDueDates[$task->project_id]['High'] = 1;
+                        $tasksDueDates[$task->project_id]['Medium'] = 0;
+                        $tasksDueDates[$task->project_id]['Low'] = 0;
+                    } else {
+                        $tasksDueDates[$task->project_id]['High']++;
+                    }
+                }
+                //check if task priority is Medium and due_date is between next 8-14 days, add counter
+                if ($taskDueDate > $unixTime7Days && $taskDueDate <= $unixTime14Days && $task->priority === 'Medium') {
+                    if (!key_exists($task->project_id, $tasksDueDates)) {
+                        $tasksDueDates[$task->project_id]['High'] = 0;
+                        $tasksDueDates[$task->project_id]['Medium'] = 1;
+                        $tasksDueDates[$task->project_id]['Low'] = 0;
+                    } else {
+                        $tasksDueDates[$task->project_id]['Medium']++;
+                    }
+                }
+                //check if task priority is Low and due_date is between next 15-28 days, add counter
+                if ($taskDueDate > $unixTime14Days && $taskDueDate <= $unixTime28Days && $task->priority === 'Low') {
+                    if (!key_exists($task->project_id, $tasksDueDates)) {
+                        $tasksDueDates[$task->project_id]['High'] = 0;
+                        $tasksDueDates[$task->project_id]['Medium'] = 0;
+                        $tasksDueDates[$task->project_id]['Low'] = 1;
+                    } else {
+                        $tasksDueDates[$task->project_id]['Low']++;
+                    }
+                }
+            }
+        }
+
+        $projectOwnerIds = [];
+        $projects = [];
+
+        //Get all tasks projects and project owner IDs
+        GenericModel::setCollection('projects');
+        $readProjectIdsFrom = array_merge($tasksDueDateNextTwoDays, $tasksDueDates);
+        foreach ($readProjectIdsFrom as $projectId => $taskStats) {
+            $project = GenericModel::where('_id', '=', $projectId)->first();
+            $projects[$projectId] = $project;
+            if ($project->acceptedBy) {
+                $projectOwnerIds[] = $project->acceptedBy;
+            }
+        }
+
+        $recipients = Profile::all();
+
+        //send slack notification to all admins and POs about task priority deadlines
+        foreach ($recipients as $recipient) {
+            if ($recipient->admin === true || in_array($recipient->id, $projectOwnerIds) && $recipient->slack) {
+                foreach ($projects as $projectToNotify) {
+                    if ($recipient->admin !== true && $recipient->id !== $projectToNotify->acceptedBy) {
+                        continue;
+                    }
+                    $sendTo = '@' . $recipient->slack;
+                    $webDomain = \Config::get('sharedSettings.internalConfiguration.webDomain');
+                    //send notification per project about tasks deadline in next 2 days for High priority tasks
+                    foreach ($tasksDueDateNextTwoDays as $taskProjectId => $taskList) {
+                        if ($taskProjectId === $projectToNotify->id) {
+                            foreach ($taskList as $singleTask) {
+                                $message = 'Task *'
+                                    . $singleTask->title
+                                    . '* due date in next *2 days* '
+                                    . $webDomain
+                                    . 'projects/'
+                                    . $singleTask->project_id
+                                    . '/sprints/'
+                                    . $singleTask->sprint_id
+                                    . '/tasks/'
+                                    . $singleTask->_id;
+                                Slack::sendMessage($sendTo, $message, Slack::LOW_PRIORITY);
+                            }
+                        }
+                    }
+
+                    /*Send notification per project about task deadlines for High priority in next 7 days,
+                    Medium priority in next 14 days, and low priority in next 28 days*/
+                    if (key_exists($projectToNotify->id, $tasksDueDates)) {
+                        foreach ($tasksDueDates[$projectToNotify->id] as $priority => $tasksCounted) {
+                            $message =
+                                'On project *'
+                                . $projectToNotify->name
+                                . '*, there are *'
+                                . $tasksCounted;
+                            if ($priority === 'High') {
+                                $message .= '* tasks with *High priority* in next *7 days*';
+                            }
+                            if ($priority === 'Medium') {
+                                $message .= '* tasks with *Medium priority* in next *14 days*';
+                            }
+                            if ($priority === 'Low') {
+                                $message .= '* tasks with *Low priority* in next *28 days*';
+                            }
+                            Slack::sendMessage($sendTo, $message, Slack::LOW_PRIORITY);
+                        }
+                    }
+                }
+            }
+        }
+
+        GenericModel::setCollection($preSetCollection);
+    }
+}

--- a/app/Console/Commands/UpdateTaskPriority.php
+++ b/app/Console/Commands/UpdateTaskPriority.php
@@ -11,6 +11,8 @@ use App\Helpers\Slack;
 
 class UpdateTaskPriority extends Command
 {
+    const HIGH = 'High';
+    const MEDIUM = 'Medium';
     /**
      * The name and signature of the console command.
      *
@@ -56,8 +58,8 @@ class UpdateTaskPriority extends Command
             if (empty($task->owner)) {
                 $taskDueDate = InputHandler::getUnixTimestamp($task->due_date);
                 //check if task due_date is in next 7 days and switch task priority to High if not set already
-                if ($taskDueDate >= $unixTimeNow && $taskDueDate <= $unixTime7Days && $task->priority !== 'High') {
-                    $task->priority = 'High';
+                if ($taskDueDate >= $unixTimeNow && $taskDueDate <= $unixTime7Days && $task->priority !== self::HIGH) {
+                    $task->priority = self::HIGH;
                     $task->save();
                     if (!key_exists($task->project_id, $tasksBumpedPerProject)) {
                         $tasksBumpedPerProject[$task->project_id]['High'] = 1;
@@ -68,8 +70,10 @@ class UpdateTaskPriority extends Command
                 }
                 /*check if task due_date is between next 8 - 14 days and switch task priority to Medium if not set
                  already*/
-                if ($taskDueDate > $unixTime7Days && $taskDueDate <= $unixTime14Days && $task->priority !== 'Medium') {
-                    $task->priority = 'Medium';
+                if ($taskDueDate > $unixTime7Days && $taskDueDate <= $unixTime14Days && $task->priority
+                    !== self::MEDIUM
+                ) {
+                    $task->priority = self::MEDIUM;
                     $task->save();
                     if (!key_exists($task->project_id, $tasksBumpedPerProject)) {
                         $tasksBumpedPerProject[$task->project_id]['High'] = 0;
@@ -77,7 +81,6 @@ class UpdateTaskPriority extends Command
                     } else {
                         $tasksBumpedPerProject[$task->project_id]['Medium']++;
                     }
-                    $this->info('MEDIUM');
                 }
             }
         }

--- a/app/Console/Commands/UpdateTaskPriority.php
+++ b/app/Console/Commands/UpdateTaskPriority.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\GenericModel;
+use App\Helpers\InputHandler;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class UpdateTaskPriority extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'update:task:priority';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Update task priorities based on deadline.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $preSetCollection = GenericModel::getCollection();
+        GenericModel::setCollection('tasks');
+
+        $tasks = GenericModel::all();
+        $unixTimeNow = Carbon::now()->format('U');
+        $unixTime7Days = Carbon::now()->addDays(7)->format('U');
+        $unixTime14Days = Carbon::now()->addDays(14)->format('U');
+
+        $tasksBumpedPerProject = [];
+
+        foreach ($tasks as $task) {
+            if (empty($task->owner)) {
+                $taskDueDate = InputHandler::getUnixTimestamp($task->due_date);
+                //check if task due_date is in next 7 days and switch task priority to High if not set already
+                if ($taskDueDate >= $unixTimeNow && $taskDueDate <= $unixTime7Days && $task->priority !== 'High') {
+                    $task->priority = 'High';
+                    $task->save();
+                    if (!key_exists($task->project_id, $tasksBumpedPerProject)) {
+                        $tasksBumpedPerProject[$task->project_id]['High'] = 1;
+                        $tasksBumpedPerProject[$task->project_id]['Medium'] = 0;
+                    } else {
+                        $tasksBumpedPerProject[$task->project_id]['High']++;
+                    }
+                }
+                /*check if task due_date is between next 7 - 14 days and switch task priority to Medium if not set
+                 already*/
+                if ($taskDueDate > $unixTime7Days && $taskDueDate <= $unixTime14Days && $task->priority !== 'Medium') {
+                    $task->priority = 'Medium';
+                    $task->save();
+                    if (!key_exists($task->project_id, $tasksBumpedPerProject)) {
+                        $tasksBumpedPerProject[$task->project_id]['High'] = 0;
+                        $tasksBumpedPerProject[$task->project_id]['Medium'] = 1;
+                    } else {
+                        $tasksBumpedPerProject[$task->project_id]['Medium']++;
+                    }
+                }
+            }
+        }
+
+        print_r($tasksBumpedPerProject);
+
+        GenericModel::setCollection($preSetCollection);
+    }
+}

--- a/app/Console/Commands/UpdateTaskPriority.php
+++ b/app/Console/Commands/UpdateTaskPriority.php
@@ -65,9 +65,8 @@ class UpdateTaskPriority extends Command
                     } else {
                         $tasksBumpedPerProject[$task->project_id]['High']++;
                     }
-                    $this->info('HIGH');
                 }
-                /*check if task due_date is between next 7 - 14 days and switch task priority to Medium if not set
+                /*check if task due_date is between next 8 - 14 days and switch task priority to Medium if not set
                  already*/
                 if ($taskDueDate > $unixTime7Days && $taskDueDate <= $unixTime14Days && $task->priority !== 'Medium') {
                     $task->priority = 'Medium';

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -69,5 +69,9 @@ class Kernel extends ConsoleKernel
         //Check task deadline and update priority
         $schedule->command('update:task:priority')
             ->dailyAt('07:00');
+
+        //Check task deadlines based on priority and ping admins
+        $schedule->command('ping:admins:task:priority')
+            ->dailyAt('07:00');
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -23,6 +23,7 @@ class Kernel extends ConsoleKernel
         Commands\MonthlyMinimumCheck::class,
         Commands\NotifyAdminsTaskDeadline::class,
         Commands\SlackSendMessages::class,
+        Commands\UpdateTaskPriority::class,
     ];
 
     /**
@@ -63,5 +64,9 @@ class Kernel extends ConsoleKernel
 
         // Check for messages to send every minute
         $schedule->command('slack:send-messages');
+
+        //Check task deadline and update priority
+        $schedule->command('update:task:priority')
+            ->dailyAt('07:00');
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,6 +24,7 @@ class Kernel extends ConsoleKernel
         Commands\NotifyAdminsTaskDeadline::class,
         Commands\SlackSendMessages::class,
         Commands\UpdateTaskPriority::class,
+        Commands\NotifyAdminsTaskPriority::class,
     ];
 
     /**

--- a/tests/Services/ProfilePerformanceTest.php
+++ b/tests/Services/ProfilePerformanceTest.php
@@ -55,6 +55,7 @@ class ProfilePerformanceTest extends TestCase
                     'qaProgressSeconds' => 0,
                     'qaProgressTotalSeconds' => 0,
                     'blockedSeconds' => 0,
+                    'workTrackTimestamp' => $task->work[$this->profile->id]['workTrackTimestamp'],
                     'taskLastOwner' => true,
                     'taskCompleted' => false,
                 ]
@@ -90,6 +91,7 @@ class ProfilePerformanceTest extends TestCase
         $this->assertArrayHasKey('qaProgressSeconds', $profilePerformanceArray);
         $this->assertArrayHasKey('qaProgressTotalSeconds', $profilePerformanceArray);
         $this->assertArrayHasKey('blockedSeconds', $profilePerformanceArray);
+        $this->assertArrayHasKey('workTrackTimestamp', $profilePerformanceArray);
 
 
         $this->assertEquals(false, $profilePerformanceArray['taskCompleted']);


### PR DESCRIPTION
Refactor XP award / deduct logic

1. Award XP for task done before the deadline - same logic for calculation as it is currently for under 75% of estimate delivery
2. Deduct 5 XP if deadline is missed
3. Cron that will update tasks priority based on deadline on daily basis at 8:00 AM:
  - if deadline is in 7 days, bump priority to High
  - if deadline is in 14 days, bump priority to Medium
  - send slack notification about number of task priorities bumped to PO / admin per project
4. Cron that will ping PO / admin daily on slack with following:
  - task names and links for high priority tasks if deadline is in 2 days
  - number of high priority tasks that are due in next 7 days
  - number of medium priority tasks due in next 14 days
  - number of low priority tasks in next 28 days
5. Record XP coefficient on task when claiming, account for that on XP update instead of calculating at time of passing QA to avoid situation where priority is changed while task was worked on / higher priority task appears
6. Update unit tests

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58a95bdb3e5bbe572360d586/tasks/58a9611f3e5bbe572360d599)

## Checklist

- [x] Tests covered

## Test notes
1. Create one task set due date +1 day. Submit for QA, pass QA. XP awarded.
2. Create one task due date -1 day. Submit for QA, pass QA. XP deducted -5..
3. Create few tasks with deadlines for example in 5 days, 7days, 10 days, 20 days... run cron command 
update:task:priority to update task priorities and send slack notification to admins/Po
4. Create few tasks with different deadlines and priorities. run cron command ping:admins:task:deadline to send slack notification for tasks as it's described in task.
5. Task priority is set to task (priorityCoefficient) when task is created with owner, or when assigned/claimed so when task is reassigned it will still be same task priority coefficient on XP awarding.
6. Unit tests updated