### PR TITLE
Refactor task status settings

### DIFF
--- a/app/Listeners/TaskStatusHistory.php
+++ b/app/Listeners/TaskStatusHistory.php
@@ -38,7 +38,7 @@ class TaskStatusHistory
             }
 
             //update task_history if task is paused or resumed without QA in progress
-            if (key_exists('paused', $newValues) && (!key_exists('qa_progress', $newValues))) {
+            if (key_exists('paused', $newValues) && (!key_exists('qa_in_progress', $newValues))) {
                 $taskHistory[] = [
                     'user' => $taskOwner->_id,
                     'timestamp' => (int)($unixTime . '000'),
@@ -60,19 +60,18 @@ class TaskStatusHistory
             }
 
             //update task_history if task is set to QA in progress
-            if (key_exists('qa_progress', $newValues) && $newValues['qa_progress'] === true) {
+            if (key_exists('qa_in_progress', $newValues) && $newValues['qa_in_progress'] === true) {
                 $task->submitted_for_qa = false;
                 $taskHistory[] = [
                     'user' => $taskOwner->_id,
                     'timestamp' => (int)($unixTime . '000'),
-                    'event' => $taskHistoryStatuses['qa_progress'],
-                    'status' => 'qa_progress'
+                    'event' => $taskHistoryStatuses['qa_in_progress'],
+                    'status' => 'qa_in_progress'
                 ];
-
             }
 
             //if task fails QA set task to paused and update task_history for paused
-            if (key_exists('qa_progress', $newValues) && $newValues['qa_progress'] === false) {
+            if (key_exists('qa_in_progress', $newValues) && $newValues['qa_in_progress'] === false) {
                 $task->paused = true;
                 $taskHistory[] = [
                     'user' => $taskOwner->_id,
@@ -84,7 +83,7 @@ class TaskStatusHistory
 
             //update task_history if task passed QA
             if (key_exists('passed_qa', $newValues) && $newValues['passed_qa'] === true) {
-                $task->qa_progress = false;
+                $task->qa_in_progress = false;
                 $taskHistory[] = [
                     'user' => $taskOwner->_id,
                     'timestamp' => (int)($unixTime . '000'),

--- a/app/Listeners/TaskStatusHistory.php
+++ b/app/Listeners/TaskStatusHistory.php
@@ -49,6 +49,21 @@ class TaskStatusHistory
                 ];
             }
 
+            //update task_history if task is blocked/unblocked
+            if (key_exists('blocked', $newValues)) {
+                if ($newValues['blocked'] === false) {
+                    $task->paused = true;
+                }
+                $taskHistory[] = [
+                    'user' => $taskOwner->_id,
+                    'timestamp' => (int)($unixTime . '000'),
+                    'event' => $newValues['blocked'] === true ?
+                        str_replace('%s', 'blocked', $taskHistoryStatuses['blocked'])
+                        : str_replace('%s', 'unblocked', $taskHistoryStatuses['blocked']),
+                    'status' => $newValues['blocked'] === true ? 'blocked' : 'unblocked'
+                ];
+            }
+
             //update task_history if task is submitted for QA
             if (key_exists('submitted_for_qa', $newValues) && $newValues['submitted_for_qa'] === true) {
                 $taskHistory[] = [

--- a/config/sharedSettings.php
+++ b/config/sharedSettings.php
@@ -66,7 +66,7 @@ return [
             'qa_fail' => 'Task failed QA',
             'qa_success' => 'Task passed QA',
             'blocked' => 'Task is currently blocked',
-            'qa_progress' => 'Task is in QA progress'
+            'qa_in_progress' => 'Task is in QA progress'
         ],
         'taskComplexityOptions' => [
             1,

--- a/config/sharedSettings.php
+++ b/config/sharedSettings.php
@@ -65,7 +65,7 @@ return [
             'qa_ready' => 'Task ready for QA',
             'qa_fail' => 'Task failed QA',
             'qa_success' => 'Task passed QA',
-            'blocked' => 'Task is currently blocked',
+            'blocked' => 'Task is currently : %s',
             'qa_in_progress' => 'Task is in QA progress'
         ],
         'taskComplexityOptions' => [


### PR DESCRIPTION
Added blocked field to work with task status blocked/unblocked. Updated sharedSettings, updated qa_progress field name to qa_in_progress