### PR TITLE
Fixed XP deduct/award to check due date as date not timestamp

### DIFF
--- a/app/Listeners/TaskUpdateXP.php
+++ b/app/Listeners/TaskUpdateXP.php
@@ -8,8 +8,8 @@ use App\Helpers\InputHandler;
 use App\Helpers\Slack;
 use App\Profile;
 use App\Services\ProfilePerformance;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Input;
 
 /**
  * Class TaskUpdateXP
@@ -58,9 +58,13 @@ class TaskUpdateXP
                 . $task->_id
                 . ')';
 
+            $taskFinishedUnixTime = InputHandler::getUnixTimestamp($taskDetails['workTrackTimestamp']);
+            $taskDueDateUnixTime = InputHandler::getUnixTimestamp($task->due_date);
+            $taskFinishedDate = Carbon::createFromFormat('U', $taskFinishedUnixTime)->format('Y-m-d');
+            $taskDueDate = Carbon::createFromFormat('U', $taskDueDateUnixTime)->format('Y-m-d');
             $taskXp = (float) $mappedValues['xp'];
-            if (InputHandler::getUnixTimestamp($taskDetails['workTrackTimestamp'])
-                <= InputHandler::getUnixTimestamp($task->due_date)) {
+
+            if ($taskFinishedDate <= $taskDueDate) {
                 $xpDiff = $taskXp;
                 $message = 'Task Delivered on time: ' . $taskLink;
             } else {


### PR DESCRIPTION
Fix issue with deadline check on xp listener

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58a95bdb3e5bbe572360d586/tasks/58b000cb3e5bbe764e280513)

## Checklist

- [x] Tests covered

## Test notes

Create some task with due date - yesterday. Then claim/qa/qaprogress/pass qa. 
Create some task with due date - today. Finish the task.
Create some task with due date - tomorrow. Finish the task.