### PR TITLE
Listener to ping PO on slack when task is blocked

### DIFF
--- a/app/Events/TaskBlockedNotifyProjectOwner.php
+++ b/app/Events/TaskBlockedNotifyProjectOwner.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Events;
+
+use App\GenericModel;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Class TaskBlockedNotifyProjectOwner
+ * @package App\Events
+ */
+class TaskBlockedNotifyProjectOwner extends Event
+{
+    use SerializesModels;
+
+    public $model;
+
+    /**
+     * TaskBlockedNotifyProjectOwner constructor.
+     * @param GenericModel $model
+     */
+    public function __construct(GenericModel $model)
+    {
+        $this->model = $model;
+    }
+
+    /**
+     * Get the channels the event should be broadcast on.
+     *
+     * @return array
+     */
+    public function broadcastOn()
+    {
+        return [];
+    }
+}

--- a/app/Listeners/TaskBlockedNotifyProjectOwner.php
+++ b/app/Listeners/TaskBlockedNotifyProjectOwner.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Listeners;
+
+use App\GenericModel;
+use App\Profile;
+use App\Helpers\Slack;
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Class TaskBlockedNotifyProjectOwner
+ * @package App\Listeners
+ */
+class TaskBlockedNotifyProjectOwner
+{
+    /**
+     * Handle the event.
+     * @param \App\Events\TaskBlockedNotifyProjectOwner $event
+     * @return bool
+     */
+    public function handle(\App\Events\TaskBlockedNotifyProjectOwner $event)
+    {
+        $task = $event->model;
+
+        if ($task->isDirty() && $task['collection'] === 'tasks') {
+            $updatedFields = $task->getDirty();
+
+            if (key_exists('blocked', $updatedFields) && $updatedFields['blocked'] === true) {
+                $preSetCollection = GenericModel::getCollection();
+                GenericModel::setCollection('projects');
+                $project = GenericModel::find($task->project_id);
+                GenericModel::setCollection($preSetCollection);
+
+                // Get project owner and send slack message that task is blocked
+                $po = Profile::find($project->acceptedBy);
+                if ($po && $po->slack) {
+                    $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
+                    $recipient = '@' . $po->slack;
+                    $message = 'Hey, task *'
+                        . $task->title
+                        . '* is currently blocked! '
+                        . $webDomain
+                        . 'projects/'
+                        . $task->project_id
+                        . '/sprints/'
+                        . $task->sprint_id
+                        . '/tasks/'
+                        . $task->_id;
+                    Slack::sendMessage($recipient, $message, Slack::HIGH_PRIORITY);
+
+                    return true;
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/database/seeds/ListenerRulesSeeder.php
+++ b/database/seeds/ListenerRulesSeeder.php
@@ -38,6 +38,9 @@ namespace {
                             'App\Events\TaskSettingStatus' => [
                                 'App\Listeners\TaskSettingStatus'
                             ],
+                            'App\Events\TaskBlockedNotifyProjectOwner' => [
+                                'App\Listeners\TaskBlockedNotifyProjectOwner'
+                            ],
                             'App\Events\TaskStatusHistory' => [
                                 'App\Listeners\TaskStatusHistory'
                             ],

--- a/tests/Collections/ProjectRelated.php
+++ b/tests/Collections/ProjectRelated.php
@@ -94,6 +94,21 @@ trait ProjectRelated
     }
 
     /**
+     * Get new sprint
+     * @return GenericModel
+     */
+    public function getNewSprint()
+    {
+        GenericModel::setCollection('sprints');
+        return new GenericModel(
+            [
+                'project_id' => '',
+                'title' => 'Test Sprint'
+            ]
+        );
+    }
+
+    /**
      * Get assigned task
      * @return GenericModel
      */

--- a/tests/Listeners/TaskBlockedNotifyProjectOwnerTest.php
+++ b/tests/Listeners/TaskBlockedNotifyProjectOwnerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Listeners;
+
+use App\GenericModel;
+use App\Listeners\TaskBlockedNotifyProjectOwner;
+use Tests\TestCase;
+use Tests\Collections\ProjectRelated;
+use Tests\Collections\ProfileRelated;
+use App\Profile;
+
+/**
+ * Class TaskBlockedNotifyProjectOwnerTest
+ * @package Tests\Listeners
+ */
+class TaskBlockedNotifyProjectOwnerTest extends TestCase
+{
+    use ProjectRelated, ProfileRelated;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->profile = Profile::create();
+
+        $this->profile->save();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->profile->delete();
+    }
+
+    /**
+     * Test listener to send slack message to PO when task is blocked with HIGH priority
+     */
+    public function testTaskBlockedNotifyProjectOwnerListenerSendMessage()
+    {
+        // Get new project
+        $project = $this->getNewProject();
+        $project->acceptedBy = $this->profile->id;
+        $project->save();
+
+        // Get new sprint
+        $sprint = $this->getNewSprint();
+        $sprint->project_id = $project->id;
+        $sprint->save();
+
+        // Assigned 30 minutes ago
+        $minutesWorking = 30;
+        $assignedAgo = (int)(new \DateTime())->sub(new \DateInterval('PT' . $minutesWorking . 'M'))->format('U');
+
+        $task = $this->getAssignedTask($assignedAgo);
+        $task->title = 'Test';
+        $task->project_id = $project->id;
+        $task->sprint_id = $sprint->id;
+        $task->save();
+
+        // Set profile slack
+        $this->profile->slack = 'slacktest';
+        $this->profile->save();
+
+        // Call event and listener
+        $task->blocked = true;
+        $event = new \App\Events\TaskBlockedNotifyProjectOwner($task);
+        $listener = new TaskBlockedNotifyProjectOwner($task);
+        $response = $listener->handle($event);
+
+
+        // Get message from slackMessages collection
+        $recipient = '@' . $this->profile->slack;
+        GenericModel::setCollection('slackMessages');
+        $messageRecord = GenericModel::where('recipient', '=', $recipient)
+            ->orderBy('_id', 'desc')
+            ->first();
+
+        $this->assertEquals(true, $response);
+        $this->assertEquals($messageRecord->recipient, $recipient);
+        $this->assertEquals(
+            'Hey, task *'
+            . $task->title
+            . '* is currently blocked! http://the-shop.io:3000/projects/'
+            . $project->id
+            . '/sprints/'
+            . $sprint->id
+            . '/tasks/'
+            . $task->id,
+            $messageRecord->message
+        );
+        $this->assertEquals(0, $messageRecord->priority);
+        $this->assertEquals(false, $messageRecord->sent);
+    }
+
+    /**
+     * Test listener for task blocked without project owner set
+     */
+    public function testTaskBlockedNotifyProjectOwnerListenerWithoutPo()
+    {
+        // Get new project
+        $project = $this->getNewProject();
+        $project->save();
+
+        // Assigned 30 minutes ago
+        $minutesWorking = 30;
+        $assignedAgo = (int)(new \DateTime())->sub(new \DateInterval('PT' . $minutesWorking . 'M'))->format('U');
+
+        $task = $this->getAssignedTask($assignedAgo);
+        $task->title = 'Test';
+        $task->project_id = $project->id;
+        $task->save();
+
+        // Call event and listener
+        $task->blocked = true;
+        $event = new \App\Events\TaskBlockedNotifyProjectOwner($task);
+        $listener = new TaskBlockedNotifyProjectOwner($task);
+        $response = $listener->handle($event);
+
+        $this->assertEquals(false, $response);
+    }
+}


### PR DESCRIPTION
Listener to ping PO on Slack when task is blocked

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58a95bdb3e5bbe572360d586/tasks/58aeeb323e5bbe5de26d2f8a)

## Checklist

- [x] Seeders written
- [x] Tests covered

## Test notes

Create new task, assign and set task to blocked. Query DB on slackMessages collection to check new record for slack notification to PO with HIGH priority. Seed database cause ListenerRules seeder is updated.