### PR TITLE
Profile performance to account for passed_qa

### DIFF
--- a/tests/Services/ProfilePerformanceTest.php
+++ b/tests/Services/ProfilePerformanceTest.php
@@ -200,7 +200,6 @@ class ProfilePerformanceTest extends TestCase
         foreach ($workDays as $day) {
             $unixDay = \DateTime::createFromFormat('Y-m-d', $day)->format('U');
             $task = $this->getAssignedTask($unixDay);
-            $task->save();
             $task->estimatedHours = 1;
             $task->project_id = $project->id;
             if ($counter % 2 === 0) {

--- a/tests/Services/ProfilePerformanceTest.php
+++ b/tests/Services/ProfilePerformanceTest.php
@@ -19,12 +19,13 @@ class ProfilePerformanceTest extends TestCase
     {
         parent::setUp();
 
-        $this->setTaskOwner(new Profile());
+        $this->setTaskOwner(Profile::create());
+        $this->profile->xp = 200;
+        $this->profile->save();
 
         $this->projectOwner = new Profile();
 
         $this->projectOwner->save();
-        $this->profile->save();
     }
 
     public function tearDown()
@@ -183,5 +184,44 @@ class ProfilePerformanceTest extends TestCase
         $out = $pp->aggregateForTimeRange($this->profile, $twoDaysBeforeFirstWorkDay, $firstWorkDay);
 
         $this->assertEquals(1, $out['xpDiff']);
+    }
+
+    /**
+     * Test profile performance for six days time range, with some tasks within time range and out of time range
+     */
+    public function testProfilePerformanceTaskCalculationDeliveryForTimeRangeSixDays()
+    {
+        $project = $this->getNewProject();
+        $project->save();
+
+        $workDays = WorkDays::getWorkDays();
+        $tasks = [];
+        $counter = 1;
+        foreach ($workDays as $day) {
+            $unixDay = \DateTime::createFromFormat('Y-m-d', $day)->format('U');
+            $task = $this->getAssignedTask($unixDay);
+            $task->save();
+            $task->estimatedHours = 1;
+            $task->project_id = $project->id;
+            if ($counter % 2 === 0) {
+                $task->passed_qa = true;
+            }
+            $task->save();
+            $tasks[$unixDay] = $task;
+            $counter++;
+        }
+
+        $workDaysUnixTimestamps = array_keys($tasks);
+
+        $pp = new ProfilePerformance();
+        $out = $pp->aggregateForTimeRange($this->profile, $workDaysUnixTimestamps[0], $workDaysUnixTimestamps[5]);
+
+        $this->assertEquals(100, $out['estimatedHours']);
+        $this->assertEquals(15, $out['hoursDelivered']);
+        $this->assertEquals(3000, $out['totalPayoutExternal']);
+        $this->assertEquals(1500, $out['realPayoutExternal']);
+        $this->assertEquals(0, $out['totalPayoutInternal']);
+        $this->assertEquals(0, $out['totalPayoutInternal']);
+        $this->assertEquals(0, $out['realPayoutInternal']);
     }
 }


### PR DESCRIPTION
Account for `qa_passed` time on profile performance aggregation

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58a95bdb3e5bbe572360d586/tasks/58b040623e5bbe2ece39a7c8)

## Checklist

- [x] Tests covered

## Test notes

Create for example 10 tasks with different due dates. Claim some tasks, and some of them finish. Then check profile peformance time range aggregation. Unit test covered.