### PR TITLE
Added colorIndicator for task status blocked and qa_in_progress

### DIFF
--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -65,6 +65,14 @@ class Task implements AdaptersInterface
             if ($this->task->submitted_for_qa === true) {
                 $colorIndicator = 'blue';
             }
+
+            if ($this->task->blocked === true) {
+                $colorIndicator = 'brown';
+            }
+
+            if ($this->task->qa_in_progress === true) {
+                $colorIndicator = 'dark_green';
+            }
         }
 
         if ($this->task->passed_qa === true) {

--- a/tests/Adapters/TaskTest.php
+++ b/tests/Adapters/TaskTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Adapters;
+
+use Tests\Collections\ProfileRelated;
+use Tests\Collections\ProjectRelated;
+use Tests\TestCase;
+use App\Profile;
+
+/**
+ * Class Task
+ * @package Tests\Adapters
+ */
+class TaskTest extends TestCase
+{
+    use ProjectRelated, ProfileRelated;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->setTaskOwner(Profile::create());
+        $this->profile->xp = 200;
+        $this->profile->save();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->profile->delete();
+    }
+
+    /**
+     * Test task status blocked colorIndicator on task adapter
+     */
+    public function testTaskAdapterColorIndicatorForBlocked()
+    {
+        $task = $this->getAssignedTask();
+        $task->blocked = true;
+        $task->save();
+
+        $taskAdapter = new \App\Adapters\Task($task);
+        $out = $taskAdapter->process();
+
+        $this->assertEquals('brown', $out->colorIndicator);
+    }
+
+    /**
+     *  Test task status qa_in_progress colorIndicator on task adapter
+     */
+    public function testTaskAdapterColorIndicatorForQaInProgress()
+    {
+        $task = $this->getAssignedTask();
+        $task->qa_in_progress = true;
+        $task->save();
+
+        $taskAdapter = new \App\Adapters\Task($task);
+        $out = $taskAdapter->process();
+
+        $this->assertEquals('dark_green', $out->colorIndicator);
+    }
+}

--- a/tests/GenericModel/GenericModelTest.php
+++ b/tests/GenericModel/GenericModelTest.php
@@ -46,7 +46,7 @@ class GenericModelTest extends TestCase
     /**
      * Test model unArchive
      */
-    public function testGenericModelunArchive()
+    public function testGenericModelUnArchive()
     {
         $project = $this->getNewArchivedProject();
         $project->save();
@@ -68,7 +68,7 @@ class GenericModelTest extends TestCase
     /**
      * Test model unArchive with wrong collection - exception error
      */
-    public function testGenericModelunArchiveWrongCollection()
+    public function testGenericModelUnArchiveWrongCollection()
     {
         $project = $this->getNewProject();
         $project->save();


### PR DESCRIPTION
Add color code to `blocked` and `qa_in_progress` tasks

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58a95bdb3e5bbe572360d586/tasks/58afffc83e5bbe19687c5791)

## Checklist

- [x] Tests covered

## Test notes

Create task and assign it. After that set task to blocked, and check colorIndicator status, later set task to qa_in_progress and check colorIndicator status.

