### PR TITLE
Change Cloud skill name to DevOps, migration written

### DIFF
--- a/config/sharedSettings.php
+++ b/config/sharedSettings.php
@@ -86,7 +86,7 @@ return [
         'skills' => [
             'PHP',
             'React',
-            'Cloud',
+            'DevOps',
             'Node',
             'Planning'
         ],

--- a/database/migrations/2017_02_27_155717_rename_cloud_skill_to_dev_ops.php
+++ b/database/migrations/2017_02_27_155717_rename_cloud_skill_to_dev_ops.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace {
+
+    use App\GenericModel;
+    use App\Profile;
+    use Illuminate\Database\Migrations\Migration;
+
+    /**
+     * Class RenameCloudSkillToDevOps
+     */
+    class RenameCloudSkillToDevOps extends Migration
+    {
+        /**
+         * Run the migrations.
+         *
+         * @return void
+         */
+        public function up()
+        {
+            GenericModel::setCollection('tasks');
+            $tasks = GenericModel::all();
+            // Rename Cloud skill to DevOps on all tasks
+            foreach ($tasks as $task) {
+                if (isset($task->skillset) && is_array($task->skillset) && in_array('Cloud', $task->skillset)) {
+                    $skillSet = $task->skillset;
+                    $needle = "Cloud";
+                    $replacement = "DevOps";
+                    for ($i = 0; $i < count($skillSet); $i++) {
+                        if ($skillSet[$i] === $needle) {
+                            $skillSet[$i] = $replacement;
+                        }
+                    }
+                    $task->skillset = $skillSet;
+                    $task->save();
+                }
+            }
+
+            $profiles = Profile::all();
+            // Rename Cloud skill to DevOps on all profiles
+            foreach ($profiles as $profile) {
+                if (isset($profile->skills) && is_array($profile->skills) && in_array('Cloud', $profile->skills)) {
+                    $skills = $profile->skills;
+                    $skillNeedle = "Cloud";
+                    $replacementSkill = "DevOps";
+                    for ($i = 0; $i < count($skills); $i++) {
+                        if ($skills[$i] === $skillNeedle) {
+                            $skills[$i] = $replacementSkill;
+                        }
+                    }
+                    $profile->skills = $skills;
+                    $profile->save();
+                }
+            }
+        }
+
+        /**
+         * Reverse the migrations.
+         *
+         * @return void
+         */
+        public function down()
+        {
+            //
+        }
+    }
+}


### PR DESCRIPTION
Rename `Cloud` skill to `DevOps`

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58a95bdb3e5bbe572360d586/tasks/58ac0eed3e5bbe4df8459885)

## Checklist

- [x] Migrations written
- [x] Tests covered

## Test notes
Migration written to change task skillset if there is 'Cloud' skill to 'DevOps' and to go through database to change on profile->skills  if 'Cloud' skill exists. As i have seen, there is no code that depends on 'skill' name, except sharedSettings where skill name is defined and i believe that FE generates that from sharedSettings also.