### PR TITLE
Profile performance endpoint to output `timeDoingQA`

### DIFF
--- a/app/Listeners/TaskStatusHistory.php
+++ b/app/Listeners/TaskStatusHistory.php
@@ -27,6 +27,7 @@ class TaskStatusHistory
             //update task_history if task is claimed or assigned
             if (key_exists('owner', $newValues)) {
                 $taskOwner = Profile::find($newValues['owner']);
+                $task->timeAssigned = $unixTime;
                 $taskHistory[] = [
                     'user' => $taskOwner->_id,
                     'timestamp' => (int)($unixTime . '000'),
@@ -98,6 +99,7 @@ class TaskStatusHistory
 
             //update task_history if task passed QA
             if (key_exists('passed_qa', $newValues) && $newValues['passed_qa'] === true) {
+                $task->timeFinished = $unixTime;
                 $task->qa_in_progress = false;
                 $taskHistory[] = [
                     'user' => $taskOwner->_id,

--- a/app/Listeners/TaskStatusHistory.php
+++ b/app/Listeners/TaskStatusHistory.php
@@ -27,7 +27,7 @@ class TaskStatusHistory
             //update task_history if task is claimed or assigned
             if (key_exists('owner', $newValues)) {
                 $taskOwner = Profile::find($newValues['owner']);
-                $task->timeAssigned = $unixTime;
+                $task->timeAssigned = (int) $unixTime;
                 $taskHistory[] = [
                     'user' => $taskOwner->_id,
                     'timestamp' => (int)($unixTime . '000'),
@@ -99,7 +99,7 @@ class TaskStatusHistory
 
             //update task_history if task passed QA
             if (key_exists('passed_qa', $newValues) && $newValues['passed_qa'] === true) {
-                $task->timeFinished = $unixTime;
+                $task->timeFinished = (int) $unixTime;
                 $task->qa_in_progress = false;
                 $taskHistory[] = [
                     'user' => $taskOwner->_id,

--- a/app/Listeners/TaskStatusTimeCalculation.php
+++ b/app/Listeners/TaskStatusTimeCalculation.php
@@ -47,7 +47,7 @@ class TaskStatusTimeCalculation
         $taskPriorityCoefficient = $profilePerformance->taskPriorityCoefficient($taskOwnerProfile, $task);
 
         if ($task->exists === false) {
-            $task->timeAssigned = $unixTime;
+            $task->timeAssigned = (int) $unixTime;
             $task->priorityCoefficient = $taskPriorityCoefficient;
             $task->work = [
                 $taskOwner => [

--- a/app/Listeners/TaskStatusTimeCalculation.php
+++ b/app/Listeners/TaskStatusTimeCalculation.php
@@ -47,6 +47,7 @@ class TaskStatusTimeCalculation
         $taskPriorityCoefficient = $profilePerformance->taskPriorityCoefficient($taskOwnerProfile, $task);
 
         if ($task->exists === false) {
+            $task->timeAssigned = $unixTime;
             $task->priorityCoefficient = $taskPriorityCoefficient;
             $task->work = [
                 $taskOwner => [

--- a/app/Services/ProfilePerformance.php
+++ b/app/Services/ProfilePerformance.php
@@ -128,7 +128,7 @@ class ProfilePerformance
             'realPayoutInternal' => $realPayoutInternal,
             'totalPayoutCombined' => $totalPayoutCombined,
             'realPayoutCombined' => $realPayoutCombined,
-            'timeDoingQA' => $timeDoingQaHours,
+            'hoursDoingQA' => $timeDoingQaHours,
             'xpDiff' => $xpDiff,
             'xpTotal' => $profile->xp,
         ];

--- a/app/Services/ProfilePerformance.php
+++ b/app/Services/ProfilePerformance.php
@@ -23,9 +23,6 @@ class ProfilePerformance
      */
     public function aggregateForTimeRange(Profile $profile, $unixStart, $unixEnd)
     {
-        $unixStartDate = Carbon::createFromFormat('U', InputHandler::getUnixTimestamp($unixStart))->format('Y-m-d');
-        $unixEndDate = Carbon::createFromFormat('U', InputHandler::getUnixTimestamp($unixEnd))->format('Y-m-d');
-
         // Get all profile tasks
         GenericModel::setCollection('tasks');
         $profileTasksUnfinished = GenericModel::where('owner', '=', $profile->id)
@@ -41,8 +38,6 @@ class ProfilePerformance
             ->get();
 
         $profileTasks = $profileTasksUnfinished->merge($profileTasksFinished);
-
-
 
         $estimatedHours = 0;
         $hoursDelivered = 0;
@@ -74,7 +69,7 @@ class ProfilePerformance
                     }
                 }
             } else {
-                $estimatedHours += (float)$task->estimatedHours;
+                $estimatedHours += (float)$task->estimatedHours; // For old tasks without work field
             }
 
 
@@ -123,7 +118,7 @@ class ProfilePerformance
         // Sum up totals
         $totalPayoutCombined = $totalPayoutExternal + $totalPayoutInternal;
         $realPayoutCombined = $realPayoutExternal + $realPayoutInternal;
-
+        $timeDoingQaHours = $this->roundFloat(($timeDoingQa / 60 / 60), 2, 5);
         $out = [
             'estimatedHours' => $estimatedHours,
             'hoursDelivered' => $hoursDelivered,
@@ -133,7 +128,7 @@ class ProfilePerformance
             'realPayoutInternal' => $realPayoutInternal,
             'totalPayoutCombined' => $totalPayoutCombined,
             'realPayoutCombined' => $realPayoutCombined,
-            'timeDoingQA' => $timeDoingQa,
+            'timeDoingQA' => $timeDoingQaHours,
             'xpDiff' => $xpDiff,
             'xpTotal' => $profile->xp,
         ];

--- a/database/migrations/2017_03_02_095214_update_task_add_fields_timeAssigned_and_timeFinished.php
+++ b/database/migrations/2017_03_02_095214_update_task_add_fields_timeAssigned_and_timeFinished.php
@@ -24,18 +24,18 @@ namespace {
                     if (isset($task->work)) {
                         foreach ($task->work as $workStats) {
                             if (!key_exists('timeRemoved', $workStats)) {
-                                $task->timeAssigned = $workStats['timeAssigned'];
-                                $task->timeFinished = $workStats['workTrackTimestamp'];
+                                $task->timeAssigned = (int) $workStats['timeAssigned'];
+                                $task->timeFinished = (int) $workStats['workTrackTimestamp'];
                                 $task->save();
                             }
                         }
                     } else {
                         foreach ($task->task_history as $historyItem) {
                             if ($historyItem['status'] === 'claimed' || $historyItem['status'] === 'assigned') {
-                                $task->timeAssigned = $historyItem['timestamp'];
+                                $task->timeAssigned = (int) $historyItem['timestamp'];
                             }
                             if ($historyItem['status'] === 'qa_success') {
-                                $task->timeFinished = $historyItem['timestamp'];
+                                $task->timeFinished = (int) $historyItem['timestamp'];
                                 $task->save();
                             }
                         }
@@ -44,16 +44,14 @@ namespace {
                     if (isset($task->work)) {
                         foreach ($task->work as $workStatistic) {
                             if (!key_exists('timeRemoved', $workStatistic)) {
-                                $task->timeAssigned = $workStatistic['timeAssigned'];
-                                $task->timeFinished = null;
+                                $task->timeAssigned = (int) $workStatistic['timeAssigned'];
                                 $task->save();
                             }
                         }
                     } else {
                         foreach ($task->task_history as $historyItem) {
                             if ($historyItem['status'] === 'claimed' || $historyItem['status'] === 'assigned') {
-                                $task->timeAssigned = $historyItem['timestamp'];
-                                $task->timeFinished = null;
+                                $task->timeAssigned = (int) $historyItem['timestamp'];
                                 $task->save();
                             }
                         }

--- a/database/migrations/2017_03_02_095214_update_task_add_fields_timeAssigned_and_timeFinished.php
+++ b/database/migrations/2017_03_02_095214_update_task_add_fields_timeAssigned_and_timeFinished.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace {
+
+    use App\GenericModel;
+    use Illuminate\Database\Migrations\Migration;
+
+    class UpdateTaskAddFieldsTimeAssignedAndTimeFinished extends Migration
+    {
+        /**
+         * Run the migrations.
+         *
+         * @return void
+         */
+        public function up()
+        {
+            GenericModel::setCollection('tasks');
+            $tasks = GenericModel::all();
+            foreach ($tasks as $task) {
+                if (empty($task->owner)) {
+                    continue;
+                }
+                if ($task->passed_qa === true) {
+                    if (isset($task->work)) {
+                        foreach ($task->work as $workStats) {
+                            if (!key_exists('timeRemoved', $workStats)) {
+                                $task->timeAssigned = $workStats['timeAssigned'];
+                                $task->timeFinished = $workStats['workTrackTimestamp'];
+                                $task->save();
+                            }
+                        }
+                    } else {
+                        foreach ($task->task_history as $historyItem) {
+                            if ($historyItem['status'] === 'claimed' || $historyItem['status'] === 'assigned') {
+                                $task->timeAssigned = $historyItem['timestamp'];
+                            }
+                            if ($historyItem['status'] === 'qa_success') {
+                                $task->timeFinished = $historyItem['timestamp'];
+                                $task->save();
+                            }
+                        }
+                    }
+                } else {
+                    if (isset($task->work)) {
+                        foreach ($task->work as $workStatistic) {
+                            if (!key_exists('timeRemoved', $workStatistic)) {
+                                $task->timeAssigned = $workStatistic['timeAssigned'];
+                                $task->timeFinished = null;
+                                $task->save();
+                            }
+                        }
+                    } else {
+                        foreach ($task->task_history as $historyItem) {
+                            if ($historyItem['status'] === 'claimed' || $historyItem['status'] === 'assigned') {
+                                $task->timeAssigned = $historyItem['timestamp'];
+                                $task->timeFinished = null;
+                                $task->save();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /**
+         * Reverse the migrations.
+         *
+         * @return void
+         */
+        public function down()
+        {
+            //
+        }
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,7 +25,4 @@
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
     </php>
-    <logging>
-        <log type="coverage-html" target="phpunit-logging/report" lowUpperBound="50" highLowerBound="99"/>
-    </logging>
 </phpunit>

--- a/tests/Collections/ProjectRelated.php
+++ b/tests/Collections/ProjectRelated.php
@@ -123,6 +123,8 @@ trait ProjectRelated
         $task = $this->getNewTask();
 
         $task->owner = $this->profile->id;
+        $task->timeAssigned = $timestamp;
+        $task->timeFinished = null;
         $task->work = [
             $this->profile->id => [
                 'worked' => 0,

--- a/tests/Collections/ProjectRelated.php
+++ b/tests/Collections/ProjectRelated.php
@@ -123,7 +123,7 @@ trait ProjectRelated
         $task = $this->getNewTask();
 
         $task->owner = $this->profile->id;
-        $task->timeAssigned = $timestamp;
+        $task->timeAssigned = (int) $timestamp;
         $task->timeFinished = null;
         $task->work = [
             $this->profile->id => [

--- a/tests/Services/ProfilePerformanceTest.php
+++ b/tests/Services/ProfilePerformanceTest.php
@@ -191,7 +191,6 @@ class ProfilePerformanceTest extends TestCase
      */
     public function testProfilePerformanceTaskCalculationDeliveryForTimeRangeSixDays()
     {
-        $this->markTestSkipped('must be revisited.');
         $project = $this->getNewProject();
         $project->save();
 
@@ -205,7 +204,10 @@ class ProfilePerformanceTest extends TestCase
             $task->project_id = $project->id;
             if ($counter % 2 === 0) {
                 $task->passed_qa = true;
-                $task->timeFinished = $unixDay;
+                $task->timeFinished = (int) $unixDay;
+                $work = $task->work;
+                $work[$this->profile->id]['qa_total_time'] = 1800;
+                $task->work = $work;
             }
             $task->save();
             $tasks[$unixDay] = $task;
@@ -224,5 +226,6 @@ class ProfilePerformanceTest extends TestCase
         $this->assertEquals(0, $out['totalPayoutInternal']);
         $this->assertEquals(0, $out['totalPayoutInternal']);
         $this->assertEquals(0, $out['realPayoutInternal']);
+        $this->assertEquals(1.5, $out['timeDoingQA']);
     }
 }

--- a/tests/Services/ProfilePerformanceTest.php
+++ b/tests/Services/ProfilePerformanceTest.php
@@ -226,6 +226,6 @@ class ProfilePerformanceTest extends TestCase
         $this->assertEquals(0, $out['totalPayoutInternal']);
         $this->assertEquals(0, $out['totalPayoutInternal']);
         $this->assertEquals(0, $out['realPayoutInternal']);
-        $this->assertEquals(1.5, $out['timeDoingQA']);
+        $this->assertEquals(1.5, $out['hoursDoingQA']);
     }
 }

--- a/tests/Services/ProfilePerformanceTest.php
+++ b/tests/Services/ProfilePerformanceTest.php
@@ -191,6 +191,7 @@ class ProfilePerformanceTest extends TestCase
      */
     public function testProfilePerformanceTaskCalculationDeliveryForTimeRangeSixDays()
     {
+        $this->markTestSkipped('must be revisited.');
         $project = $this->getNewProject();
         $project->save();
 
@@ -204,6 +205,7 @@ class ProfilePerformanceTest extends TestCase
             $task->project_id = $project->id;
             if ($counter % 2 === 0) {
                 $task->passed_qa = true;
+                $task->timeFinished = $unixDay;
             }
             $task->save();
             $tasks[$unixDay] = $task;
@@ -215,7 +217,7 @@ class ProfilePerformanceTest extends TestCase
         $pp = new ProfilePerformance();
         $out = $pp->aggregateForTimeRange($this->profile, $workDaysUnixTimestamps[0], $workDaysUnixTimestamps[5]);
 
-        $this->assertEquals(100, $out['estimatedHours']);
+        $this->assertEquals(30, $out['estimatedHours']);
         $this->assertEquals(15, $out['hoursDelivered']);
         $this->assertEquals(3000, $out['totalPayoutExternal']);
         $this->assertEquals(1500, $out['realPayoutExternal']);


### PR DESCRIPTION
Profile performance endpoint to output `timeDoingQA`

Aggregate for time range, for people that where doing QA, sum up total time in hours

Covered with test.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58a95bdb3e5bbe572360d586/tasks/58aece633e5bbe73af55a75e)

## Checklist
- [x] Migrations written
- [x] Tests covered

## Test notes

Create few tasks and part of them finish, and leave some of them unfinished. Check your profile performance.

