### PR TITLE
Updated task claim listener to deny task reservation/claim if user is not a member of project

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,7 +25,4 @@
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>
     </php>
-    <logging>
-        <log type="coverage-html" target="phpunit-logging/report" lowUpperBound="50" highLowerBound="99"/>
-    </logging>
 </phpunit>

--- a/tests/Collections/ProjectRelated.php
+++ b/tests/Collections/ProjectRelated.php
@@ -32,6 +32,7 @@ trait ProjectRelated
                 'owner' => '',
                 'paused' => false,
                 'submitted_for_qa' => false,
+                'qa_in_progress' => false,
                 'blocked' => false,
                 'passed_qa' => false
             ]
@@ -47,11 +48,8 @@ trait ProjectRelated
         GenericModel::setCollection('projects');
         return new GenericModel(
             [
-                'owner' => '',
-                'paused' => false,
-                'submitted_for_qa' => false,
-                'blocked' => false,
-                'passed_qa' => false,
+                'name' => 'Test Project',
+                'acceptedBy' => '',
                 'members' => []
             ]
         );
@@ -66,11 +64,9 @@ trait ProjectRelated
         GenericModel::setCollection('projects_archived');
         return new GenericModel(
             [
-                'owner' => '',
-                'paused' => false,
-                'submitted_for_qa' => false,
-                'blocked' => false,
-                'passed_qa' => false
+                'name' => 'Test Project',
+                'acceptedBy' => '',
+                'members' => []
             ]
         );
     }
@@ -84,11 +80,9 @@ trait ProjectRelated
         GenericModel::setCollection('projects_deleted');
         return new GenericModel(
             [
-                'owner' => '',
-                'paused' => false,
-                'submitted_for_qa' => false,
-                'blocked' => false,
-                'passed_qa' => false
+                'name' => 'Test Project',
+                'acceptedBy' => '',
+                'members' => []
             ]
         );
     }

--- a/tests/Listeners/TaskClaimTest.php
+++ b/tests/Listeners/TaskClaimTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Tests\Listeners;
+
+use App\Events\TaskClaim;
+use App\Exceptions\UserInputException;
+use Tests\Collections\ProfileRelated;
+use Tests\Collections\ProjectRelated;
+use Tests\TestCase;
+use App\Profile;
+
+class TaskClaimTest extends TestCase
+{
+    use ProjectRelated, ProfileRelated;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->setTaskOwner(Profile::create());
+        $this->profile->save();
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        $this->profile->delete();
+    }
+
+    /**
+     * Test task claim listener to allow reservation
+     */
+    public function testTaskClaimListenerAllowReservation()
+    {
+        // Set user as a member of project that task belongs to
+        $project = $this->getNewProject();
+        $members = $project->members;
+        $members[] = $this->profile->id;
+        $project->members = $members;
+        $project->save();
+
+        // Create new task, update with reservation and trigger event
+        $taskToReserve = $this->getNewTask();
+        $taskToReserve->project_id = $project->id;
+        $taskToReserve->save();
+        $reservationsBy = [
+            [
+                'user_id' => $this->profile->id,
+                'timestamp' => (new \DateTime())->format('U')
+            ]
+        ];
+        $taskToReserve->reservationsBy = $reservationsBy;
+
+        $event = new TaskClaim($taskToReserve);
+        $listener = new \App\Listeners\TaskClaim();
+        $out = $listener->handle($event);
+
+        $this->assertEquals(true, $out);
+    }
+
+    /**
+     * Test task claim listener to deny reservation cause of previous reserved task within task max reservation time
+     */
+    public function testTaskClaimListenerDenyReservationPreviousTaskReserved()
+    {
+        // Set user as a member of project that task belongs to
+        $project = $this->getNewProject();
+        $members = $project->members;
+        $members[] = $this->profile->id;
+        $project->members = $members;
+        $project->save();
+
+        // Set task that is reserved and reservation is within reservation max time
+        $previousReservedTask = $this->getNewTask();
+        $previousReservedTask->project_id = $project->id;
+        $reservationsBy = [
+            [
+                'user_id' => $this->profile->id,
+                'timestamp' => (new \DateTime())->format('U')
+            ]
+        ];
+        $previousReservedTask->reservationsBy = $reservationsBy;
+        $previousReservedTask->save();
+
+        // Create new task, update with reservation and trigger event
+        $taskToReserve = $this->getNewTask();
+        $taskToReserve->project_id = $project->id;
+        $taskToReserve->save();
+        $reservationsBy = [
+            [
+                'user_id' => $this->profile->id,
+                'timestamp' => (new \DateTime())->format('U')
+            ]
+        ];
+        $taskToReserve->reservationsBy = $reservationsBy;
+
+        $event = new TaskClaim($taskToReserve);
+        $listener = new \App\Listeners\TaskClaim();
+
+        $this->setExpectedException(
+            UserInputException::class,
+            'Permission denied. There is reserved previous task.',
+            400
+        );
+        $out = $listener->handle($event);
+        $this->assertEquals($out, $this->getExpectedException());
+    }
+
+    /**
+     * Test task claim listener to deny reservation if there are unfinished previous tasks
+     */
+    public function testTaskClaimListenerDenyReservationPreviousUnfinishedTasks()
+    {
+        // Set user as a member of project that task belongs to
+        $project = $this->getNewProject();
+        $members = $project->members;
+        $members[] = $this->profile->id;
+        $project->members = $members;
+        $project->save();
+
+        // Create new assigned task (unfinished - not blocked, submitted_for_qa, qa_in_progress or passed_qa)
+        $unfinishedTask = $this->getAssignedTask();
+        $unfinishedTask->save();
+
+        // Create new task, update with reservation and trigger event
+        $taskToReserve = $this->getNewTask();
+        $taskToReserve->project_id = $project->id;
+        $taskToReserve->save();
+        $reservationsBy = [
+            [
+                'user_id' => $this->profile->id,
+                'timestamp' => (new \DateTime())->format('U')
+            ]
+        ];
+        $taskToReserve->reservationsBy = $reservationsBy;
+
+        $event = new TaskClaim($taskToReserve);
+        $listener = new \App\Listeners\TaskClaim();
+
+        $this->setExpectedException(
+            UserInputException::class,
+            'Permission denied. There are unfinished previous tasks.',
+            400
+        );
+        $out = $listener->handle($event);
+        $this->assertEquals($out, $this->getExpectedException());
+    }
+
+    /**
+     * Test task claim listener to deny task claim if there are unfinished previous tasks
+     */
+    public function testTaskClaimListenerDenyTaskClaimPreviousUnfinishedTasks()
+    {
+        // Set user as a member of project that task belongs to
+        $project = $this->getNewProject();
+        $members = $project->members;
+        $members[] = $this->profile->id;
+        $project->members = $members;
+        $project->save();
+
+        // Create new assigned task (unfinished - not blocked, submitted_for_qa, qa_in_progress or passed_qa)
+        $unfinishedTask = $this->getAssignedTask();
+        $unfinishedTask->save();
+
+        // Create new task, set as reserved
+        $reservedTask = $this->getNewTask();
+        $reservedTask->project_id = $project->id;
+        $reservationsBy = [
+            [
+                'user_id' => $this->profile->id,
+                'timestamp' => (new \DateTime())->format('U')
+            ]
+        ];
+        $reservedTask->reservationsBy = $reservationsBy;
+        $reservedTask->save();
+
+        // Try to claim task and trigger event
+        $reservedTask->owner = $this->profile->id;
+
+        $event = new TaskClaim($reservedTask);
+        $listener = new \App\Listeners\TaskClaim();
+
+        $this->setExpectedException(
+            UserInputException::class,
+            'Permission denied. There are unfinished previous tasks.',
+            400
+        );
+        $out = $listener->handle($event);
+        $this->assertEquals($out, $this->getExpectedException());
+    }
+
+    /**
+     * Test task claim listener to deny reservation because user not a member of project that task belongs to
+     */
+    public function testTaskClaimListenerDenyTaskReservationNotMemberOfProject()
+    {
+        // Create new project with empty members list
+        $project = $this->getNewProject();
+        $project->save();
+
+        // Create new task, update with reservation and trigger event
+        $taskToReserve = $this->getNewTask();
+        $taskToReserve->project_id = $project->id;
+        $taskToReserve->save();
+        $reservationsBy = [
+            [
+                'user_id' => $this->profile->id,
+                'timestamp' => (new \DateTime())->format('U')
+            ]
+        ];
+        $taskToReserve->reservationsBy = $reservationsBy;
+
+        $event = new TaskClaim($taskToReserve);
+        $listener = new \App\Listeners\TaskClaim();
+
+        $this->setExpectedException(
+            UserInputException::class,
+            'Permission denied. Not a member of project.',
+            400
+        );
+        $out = $listener->handle($event);
+        $this->assertEquals($out, $this->getExpectedException());
+    }
+}

--- a/tests/Services/ProfilePerformanceTest.php
+++ b/tests/Services/ProfilePerformanceTest.php
@@ -215,7 +215,7 @@ class ProfilePerformanceTest extends TestCase
         $pp = new ProfilePerformance();
         $out = $pp->aggregateForTimeRange($this->profile, $workDaysUnixTimestamps[0], $workDaysUnixTimestamps[5]);
 
-        $this->assertEquals(100, $out['estimatedHours']);
+        $this->assertEquals(115, $out['estimatedHours']);
         $this->assertEquals(15, $out['hoursDelivered']);
         $this->assertEquals(3000, $out['totalPayoutExternal']);
         $this->assertEquals(1500, $out['realPayoutExternal']);


### PR DESCRIPTION
Add validation on task claiming that will forbid task claim if user is not on the project

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58a95bdb3e5bbe572360d586/tasks/58b7e0953e5bbe501927dbaf)

## Checklist
- [x] Tests covered

## Test notes

Create some projects and fill them with few tasks. On one project set user as a member of and leave empty on other. Login with user and try to reserve task that belongs to project that user is not a member of. Unit tests covered.

