### PR TITLE
Make sure TaskUpdateXP listener don't update user XP if task is edited after QA has passed

### DIFF
--- a/app/Listeners/TaskUpdateXP.php
+++ b/app/Listeners/TaskUpdateXP.php
@@ -25,6 +25,16 @@ class TaskUpdateXP
     {
         $task = $event->model;
 
+        // Make sure not to update user XP if task is edited after QA has passed
+        if ($task->isDirty() !== true) {
+            return false;
+        } else {
+            $updatedFields = $task->getDirty();
+            if (!key_exists('passed_qa', $updatedFields) || $updatedFields['passed_qa'] !== true) {
+                return false;
+            }
+        }
+
         $profilePerformance = new ProfilePerformance();
 
         GenericModel::setCollection('tasks');
@@ -32,10 +42,6 @@ class TaskUpdateXP
         $taskPerformance = $profilePerformance->perTask($task);
 
         foreach ($taskPerformance as $profileId => $taskDetails) {
-            if ($taskDetails['taskCompleted'] === false) {
-                return false;
-            }
-
             if ($taskDetails['taskLastOwner'] === false) {
                 continue;
             }

--- a/tests/Listeners/TaskUpdateXpTest.php
+++ b/tests/Listeners/TaskUpdateXpTest.php
@@ -531,4 +531,43 @@ class TaskUpdateXpTest extends TestCase
         $this->assertEquals(200.2025, $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
+
+    /**
+     * Test listener for task that has been updated after task passed QA already
+     */
+    public function testTaskUpdateXpForTaskUpdatedAfterPassedQa()
+    {
+        $task = $this->getAssignedTask();
+        $task->passed_qa = true;
+        $task->save();
+
+        // Test finished task without any change
+        $event = new ModelUpdate($task);
+        $listener = new TaskUpdateXP($task);
+        $out = $listener->handle($event);
+
+        $this->assertEquals(false, $out);
+
+
+        // Let's make some update
+        $task->priority = 'High';
+        $task->title = 'Test';
+
+        // Test finished task with some updates
+        $event = new ModelUpdate($task);
+        $listener = new TaskUpdateXP($task);
+        $out = $listener->handle($event);
+
+        $this->assertEquals(false, $out);
+
+        $task->save();
+        $task->passed_qa = false;
+
+        // Test finished task with update passed_qa = false
+        $event = new ModelUpdate($task);
+        $listener = new TaskUpdateXP($task);
+        $out = $listener->handle($event);
+
+        $this->assertEquals(false, $out);
+    }
 }


### PR DESCRIPTION
Make sure task update won't update user XP if task is edited after QA has passed

Updated unit test.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58bfe0c93e5bbe3ced678bfb/tasks/58b4598a3e5bbe3b181fba6e)

## Checklist

- [x] Tests covered

Create some task, claim it and finish. After that try to edit that task - change some fields and save it. 