### PR TITLE
Changed adapter logic for red and orange colorIndicator status

### DIFF
--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -3,19 +3,35 @@
 namespace App\Adapters;
 
 use App\GenericModel;
+use App\Helpers\InputHandler;
 use App\Profile;
 use App\Services\ProfilePerformance;
 use Illuminate\Support\Facades\Auth;
+use Carbon\Carbon;
 
+/**
+ * Class Task
+ * @package App\Adapters
+ */
 class Task implements AdaptersInterface
 {
+    /**
+     * @var GenericModel
+     */
     public $task;
 
+    /**
+     * Task constructor.
+     * @param GenericModel $model
+     */
     public function __construct(GenericModel $model)
     {
         $this->task = $model;
     }
 
+    /**
+     * @return GenericModel
+     */
     public function process()
     {
         $profilePerformance = new ProfilePerformance();
@@ -40,41 +56,44 @@ class Task implements AdaptersInterface
 
         $taskStatus = $profilePerformance->perTask($this->task);
 
+        // Set due dates so we can check them and generate colorIndicator
+        $taskDueDate = Carbon::createFromFormat('U', InputHandler::getUnixTimestamp($this->task->due_date))
+            ->format('Y-m-d');
+        $dueDate2DaysFromNow = Carbon::now()->addDays(2)->format('Y-m-d');
+        $dueDate7DaysFromNow = Carbon::now()->addDays(7)->format('Y-m-d');
+
         $colorIndicator = '';
-        
+
+        // Set colorIndicator to red if task due date in 2 days or less
+        if ($taskDueDate <= $dueDate2DaysFromNow) {
+            $colorIndicator = 'red';
+        }
+
+        // Generate task colorIndicator
         if (!empty($taskStatus)) {
-            $taskEstimatedSeconds = $mappedValues['estimatedHours'] * 60 * 60;
-            $taskDeliveredOnTime = $taskStatus[$this->task->owner]['workSeconds'] <= $taskEstimatedSeconds;
-
-            // deadline in last 25% of the time of task
-            $lastQuarterOfTask = 0.25 * $taskEstimatedSeconds;
-
-            //generate task color status
-            if (($taskEstimatedSeconds - $taskStatus[$this->task->owner]['workSeconds']) <= $lastQuarterOfTask) {
+            // If task is claimed and due_date is within next 3-7 days, set colorIndicator to orange
+            if ($taskDueDate > $dueDate2DaysFromNow && $taskDueDate <= $dueDate7DaysFromNow) {
                 $colorIndicator = 'orange';
             }
-
-            if ($taskDeliveredOnTime === false) {
-                $colorIndicator = 'red';
-            }
-
+            // If task is paused set colorIndicator to yellow
             if ($this->task->paused === true) {
                 $colorIndicator = 'yellow';
             }
-
+            // If task is submitted for qa set colorIndicator to blue
             if ($this->task->submitted_for_qa === true) {
                 $colorIndicator = 'blue';
             }
-
+            // If task is blocked set colorIndicator to brown
             if ($this->task->blocked === true) {
                 $colorIndicator = 'brown';
             }
-
+            // If task is in qa in progress set colorIndicator to dark_green
             if ($this->task->qa_in_progress === true) {
                 $colorIndicator = 'dark_green';
             }
         }
 
+        // Set colorIndicator to green if task passed qa
         if ($this->task->passed_qa === true) {
             $colorIndicator = 'green';
         }

--- a/tests/Adapters/TaskTest.php
+++ b/tests/Adapters/TaskTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Adapters;
 
+use Carbon\Carbon;
 use Tests\Collections\ProfileRelated;
 use Tests\Collections\ProjectRelated;
 use Tests\TestCase;
@@ -59,5 +60,70 @@ class TaskTest extends TestCase
         $out = $taskAdapter->process();
 
         $this->assertEquals('dark_green', $out->colorIndicator);
+    }
+
+    /**
+     * Test task adapter colorIndicator red
+     */
+    public function testTaskAdapterColorIndicatorForTaskDueDateInNext2Days()
+    {
+        // Set task with due_date today
+        $task = $this->getAssignedTask();
+        $task->due_date = Carbon::now()->format('U');
+        $task->save();
+
+        $taskAdapter = new \App\Adapters\Task($task);
+        $out = $taskAdapter->process();
+
+        $this->assertEquals('red', $out->colorIndicator);
+
+        // Set task with due_date 2 days from today
+        $secondTask = $this->getAssignedTask();
+        $task->due_date = Carbon::now()->addDays(2)->format('U');
+        $task->save();
+
+        $taskAdapter = new \App\Adapters\Task($secondTask);
+        $out = $taskAdapter->process();
+
+        $this->assertEquals('red', $out->colorIndicator);
+    }
+
+    /**
+     * Test task adapter colorIndicator for task due_date within next 3-7 days
+     */
+    public function testTaskAdapterColorIndicatorForTaskDueDateWithinNext3to7Days()
+    {
+        // Set task with due_date 3 days from today
+        $task = $this->getAssignedTask();
+        $task->due_date = Carbon::now()->addDays(3)->format('U');
+        $task->save();
+
+        $taskAdapter = new \App\Adapters\Task($task);
+        $out = $taskAdapter->process();
+
+        $this->assertEquals('orange', $out->colorIndicator);
+
+        // Set task with due_date 6 days from today
+        $task = $this->getAssignedTask();
+        $task->due_date = Carbon::now()->addDays(6)->format('U');
+        $task->save();
+
+        $taskAdapter = new \App\Adapters\Task($task);
+        $out = $taskAdapter->process();
+
+        $this->assertEquals('orange', $out->colorIndicator);
+    }
+
+    public function testTaskAdapterColorIndicatorForTaskDueDateMoreThan7DaysFromNow()
+    {
+        // Set task with due_date 10 days from today
+        $task = $this->getAssignedTask();
+        $task->due_date = Carbon::now()->addDays(10)->format('U');
+        $task->save();
+
+        $taskAdapter = new \App\Adapters\Task($task);
+        $out = $taskAdapter->process();
+
+        $this->assertEmpty($out->colorIndicator);
     }
 }

--- a/tests/Collections/ProjectRelated.php
+++ b/tests/Collections/ProjectRelated.php
@@ -116,6 +116,7 @@ trait ProjectRelated
         GenericModel::setCollection('tasks');
         $task = $this->getNewTask();
 
+        $task->due_date = $timestamp;
         $task->owner = $this->profile->id;
         $task->timeAssigned = (int) $timestamp;
         $task->timeFinished = null;


### PR DESCRIPTION
Update task colors in adapter

Orange for tasks that are claimed and due within next 3-7 days, red for tasks that are due in 2 days or less (even if not claimed)

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58bfe0c93e5bbe3ced678bfb/tasks/58c13f073e5bbe28f02e71d0)

## Checklist
- [x] Tests covered

## Test notes

Create task with due date within next 2 days. Check task colorIndicator. 
Create task with due date within next 3-7 days. Claim task and check color indicator.