### PR TITLE
Update NotifyAdminsTaskDeadline to send slack notification to admins, Po and project members

### DIFF
--- a/app/Console/Commands/NotifyAdminsTaskDeadline.php
+++ b/app/Console/Commands/NotifyAdminsTaskDeadline.php
@@ -7,7 +7,13 @@ use App\Helpers\InputHandler;
 use App\Helpers\Slack;
 use App\Profile;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+use DateTime;
 
+/**
+ * Class NotifyAdminsTaskDeadline
+ * @package App\Console\Commands
+ */
 class NotifyAdminsTaskDeadline extends Command
 {
     /**
@@ -22,7 +28,8 @@ class NotifyAdminsTaskDeadline extends Command
      *
      * @var string
      */
-    protected $description = 'Ping admins / PO on slack about approaching task deadline 7 days before deadline';
+    protected $description =
+        'Ping project members and Po on slack about approaching task deadline 7 days before deadline';
 
     /**
      * Execute the console command.
@@ -34,34 +41,60 @@ class NotifyAdminsTaskDeadline extends Command
         GenericModel::setCollection('tasks');
         $tasks = GenericModel::all();
 
-        $unixDateNow = (new \DateTime())->format('U');
+        $unixDateNow = (new DateTime())->format('U');
         $unixSevenDaysFromNow = (int) ($unixDateNow) + 24 * 7 * 60 * 60;
-        $sevenDaysFromNowDate = \DateTime::createFromFormat('U', $unixSevenDaysFromNow)->format('Y-m-d');
+        $sevenDaysFromNowDate = DateTime::createFromFormat('U', $unixSevenDaysFromNow)->format('Y-m-d');
         foreach ($tasks as $task) {
             if (!empty($task->due_date) && $sevenDaysFromNowDate
-                === \DateTime::createFromFormat('U', InputHandler::getUnixTimestamp($task->due_date))->format('Y-m-d')
+                === DateTime::createFromFormat('U', InputHandler::getUnixTimestamp($task->due_date))->format('Y-m-d')
             ) {
+                $recipients = [];
+                // Get all project members of project that task belongs to
                 GenericModel::setCollection('projects');
                 $taskProject = GenericModel::where('_id', '=', $task->project_id)->first();
+                foreach ($taskProject->members as $memberId) {
+                    $memberProfile = Profile::find($memberId);
+                    if ($memberProfile !== null && $memberProfile->slack) {
+                        $recipients[] = '@' . $memberProfile->slack;
+                    }
+                }
+
+                // Get all admins and project owner
                 $adminsAndPo = Profile::where('admin', '=', true)
                     ->orWhere('_id', '=', $taskProject->acceptedBy)
                     ->get();
 
-                foreach ($adminsAndPo as $user) {
-                    if ($user->slack) {
-                        $taskDueDate = \DateTime::createFromFormat('U', InputHandler::getUnixTimestamp($task->due_date))
-                            ->format('Y-m-d');
-                        $recipient = '@' . $user->slack;
-                        $message = 'Hey, task *'
-                            . $task->title
-                            . '* on project *'
-                            . $taskProject->name
-                            . '* deadline is in *7 days* '
-                            . '(*'
-                            . $taskDueDate
-                            . '*)';
-                        Slack::sendMessage($recipient, $message, Slack::LOW_PRIORITY);
+                foreach ($adminsAndPo as $adminOrPo) {
+                    if ($adminOrPo->slack) {
+                        $recipients[] = '@' . $adminOrPo->slack;
                     }
+                }
+
+                // Make sure that we don't double send notifications if project member is admin or project owner
+                $recipients = array_unique($recipients);
+
+                // Create slack message
+                $taskDueDate = DateTime::createFromFormat('U', InputHandler::getUnixTimestamp($task->due_date))
+                    ->format('Y-m-d');
+                $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
+                $message = 'Hey, task *'
+                    . $task->title
+                    . '* on project *'
+                    . $taskProject->name
+                    . '* deadline is in *7 days* '
+                    . '(*'
+                    . $taskDueDate
+                    . '*) '
+                    . $webDomain
+                    . 'projects/'
+                    . $task->project_id
+                    . '/sprints/'
+                    . $task->sprint_id
+                    . '/tasks/'
+                    . $task->_id;
+                // Send messages to all recipients
+                foreach ($recipients as $recipient) {
+                    Slack::sendMessage($recipient, $message, Slack::LOW_PRIORITY);
                 }
             }
         }

--- a/app/Console/Commands/NotifyProjectParticipantsAboutTaskDeadline.php
+++ b/app/Console/Commands/NotifyProjectParticipantsAboutTaskDeadline.php
@@ -11,17 +11,17 @@ use Illuminate\Support\Facades\Config;
 use DateTime;
 
 /**
- * Class NotifyAdminsTaskDeadline
+ * Class NotifyProjectParticipantsAboutTaskDeadline
  * @package App\Console\Commands
  */
-class NotifyAdminsTaskDeadline extends Command
+class NotifyProjectParticipantsAboutTaskDeadline extends Command
 {
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'ping:admins:task:deadline';
+    protected $signature = 'ping:projectParticipants:task:deadline';
 
     /**
      * The console command description.
@@ -29,7 +29,7 @@ class NotifyAdminsTaskDeadline extends Command
      * @var string
      */
     protected $description =
-        'Ping project members and Po on slack about approaching task deadline 7 days before deadline';
+        'Ping admins,project members and project owner on slack about approaching task deadline 7 days before deadline';
 
     /**
      * Execute the console command.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -21,7 +21,7 @@ class Kernel extends ConsoleKernel
         Commands\UnfinishedTasks::class,
         Commands\EmailProfilePerformance::class,
         Commands\MonthlyMinimumCheck::class,
-        Commands\NotifyAdminsTaskDeadline::class,
+        Commands\NotifyProjectParticipantsAboutTaskDeadline::class,
         Commands\SlackSendMessages::class,
         Commands\UpdateTaskPriority::class,
         Commands\NotifyAdminsTaskPriority::class,
@@ -60,7 +60,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('employee:minimum:check')
             ->monthlyOn(1, '08:00');
 
-        $schedule->command('ping:admins:task:deadline')
+        $schedule->command('ping:projectParticipants:task:deadline')
             ->dailyAt('09:00');
 
         // Check for messages to send every minute


### PR DESCRIPTION
Update `NotifyAdminsTaskDeadline` job

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58bfe0c93e5bbe3ced678bfb/tasks/58bd701e3e5bbe0b6077456d)

## Test notes

Create a project and some tasks with different due dates. On few tasks set due_date 7 days from now. Set one user as admin role, set project members, project owner, and test NotifyAdminsTaskDeadline job. 