### PR TITLE
Profile performance task priority to account for user skill

### DIFF
--- a/app/Services/ProfilePerformance.php
+++ b/app/Services/ProfilePerformance.php
@@ -269,7 +269,7 @@ class ProfilePerformance
     {
         $taskPriorityCoefficient = 1;
 
-        //get all projects that user is a member of
+        // Get all projects that user is a member of
         $preSetCollection = GenericModel::getCollection();
         GenericModel::setCollection('projects');
         $taskOwnerProjects = GenericModel::whereIn('members', [$taskOwner->id])
@@ -279,18 +279,23 @@ class ProfilePerformance
 
         $unassignedTasksPriority = [];
 
-        //get all unassigned tasks from projects that user is a member of, and make list of tasks priority
+        // Get all unassigned tasks from projects that user is a member of, and make list of tasks priority
         foreach ($taskOwnerProjects as $project) {
             $projectTasks = GenericModel::where('project_id', '=', $project->id)
                 ->get();
             foreach ($projectTasks as $projectTask) {
-                if (empty($projectTask->owner) && !in_array($projectTask->priority, $unassignedTasksPriority)) {
+                // Let's compare user skills with task skillset
+                $compareSkills = array_intersect($taskOwner->skills, $projectTask->skillset);
+                if (empty($projectTask->owner)
+                    && !in_array($projectTask->priority, $unassignedTasksPriority)
+                    && !empty($compareSkills)
+                ) {
                     $unassignedTasksPriority[$projectTask->id] = $projectTask->priority;
                 }
             }
         }
 
-        //check task priority and compare with list of unassigned tasks priority and set task priority coefficient
+        // Check task priority and compare with list of unassigned tasks priority and set task priority coefficient
         if ($task->priority === 'Low'
             && (in_array('Medium', $unassignedTasksPriority) || in_array('High', $unassignedTasksPriority))
         ) {

--- a/tests/Collections/ProjectRelated.php
+++ b/tests/Collections/ProjectRelated.php
@@ -34,7 +34,8 @@ trait ProjectRelated
                 'submitted_for_qa' => false,
                 'qa_in_progress' => false,
                 'blocked' => false,
-                'passed_qa' => false
+                'passed_qa' => false,
+                'skillset' => []
             ]
         );
     }

--- a/tests/Listeners/TaskStatusTimeCalculationTest.php
+++ b/tests/Listeners/TaskStatusTimeCalculationTest.php
@@ -4,13 +4,14 @@ namespace Tests\Listeners;
 
 use App\Events\TaskStatusTimeCalculation;
 use App\GenericModel;
+use Tests\Collections\ProfileRelated;
 use Tests\Collections\ProjectRelated;
 use Tests\TestCase;
 use App\Profile;
 
 class TaskStatusTimeCalculationTest extends TestCase
 {
-    use ProjectRelated;
+    use ProjectRelated, ProfileRelated;
 
     public function setUp()
     {

--- a/tests/Listeners/TaskUpdateXpTest.php
+++ b/tests/Listeners/TaskUpdateXpTest.php
@@ -17,7 +17,9 @@ class TaskUpdateXpTest extends TestCase
     {
         parent::setUp();
 
-        $this->setTaskOwner(Profile::create());
+        $this->setTaskOwner(Profile::create([
+            'skills' => ['PHP']
+        ]));
         $this->profile->xp = 200;
         $this->profile->save();
     }
@@ -257,9 +259,11 @@ class TaskUpdateXpTest extends TestCase
         $project->members = $members;
         $project->save();
 
+        $skillSet = ['PHP'];
         $taskLowPriorityWithoutOwner = $this->getNewTask();
         $taskLowPriorityWithoutOwner->project_id = $project->id;
         $taskLowPriorityWithoutOwner->priority = 'Low';
+        $taskLowPriorityWithoutOwner->skillset = $skillSet;
         $taskLowPriorityWithoutOwner->save();
 
         // Assigned 30 minutes ago
@@ -272,6 +276,7 @@ class TaskUpdateXpTest extends TestCase
         $taskLowPriority->complexity = 5;
         $taskLowPriority->due_date = (new \DateTime())->modify('+1 day')->format('U');
         $taskLowPriority->project_id = $project->id;
+        $taskLowPriority->skillset = $skillSet;
         $taskLowPriority->save();
 
         $taskLowPriority->submitted_for_qa = true;
@@ -311,14 +316,22 @@ class TaskUpdateXpTest extends TestCase
         $project->members = $members;
         $project->save();
 
+        $skillSet = [
+            'PHP',
+            'React',
+            'DevOps'
+        ];
+
         $taskMediumPriorityWithoutOwner = $this->getNewTask();
         $taskMediumPriorityWithoutOwner->project_id = $project->id;
         $taskMediumPriorityWithoutOwner->priority = 'Medium';
+        $taskMediumPriorityWithoutOwner->skillset = $skillSet;
         $taskMediumPriorityWithoutOwner->save();
 
         $taskHighPriorityWithoutOwner = $this->getNewTask();
         $taskHighPriorityWithoutOwner->project_id = $project->id;
         $taskHighPriorityWithoutOwner->priority = 'High';
+        $taskHighPriorityWithoutOwner->skillset = $skillSet;
         $taskHighPriorityWithoutOwner->save();
 
         // Assigned 30 minutes ago
@@ -331,6 +344,7 @@ class TaskUpdateXpTest extends TestCase
         $taskLowPriority->complexity = 5;
         $taskLowPriority->due_date = (new \DateTime())->modify('+1 day')->format('U');
         $taskLowPriority->project_id = $project->id;
+        $taskLowPriority->skillset = $skillSet;
         $taskLowPriority->save();
 
         $taskLowPriority->submitted_for_qa = true;
@@ -371,9 +385,16 @@ class TaskUpdateXpTest extends TestCase
         $project->members = $members;
         $project->save();
 
+        $skillSet = [
+            'PHP',
+            'React',
+            'DevOps'
+        ];
+
         $taskLowPriorityWithoutOwner = $this->getNewTask();
         $taskLowPriorityWithoutOwner->project_id = $project->id;
         $taskLowPriorityWithoutOwner->priority = 'Low';
+        $taskLowPriorityWithoutOwner->skillset = $skillSet;
         $taskLowPriorityWithoutOwner->save();
 
         // Assigned 30 minutes ago
@@ -386,6 +407,7 @@ class TaskUpdateXpTest extends TestCase
         $taskMediumPriority->complexity = 5;
         $taskMediumPriority->due_date = (new \DateTime())->modify('+1 day')->format('U');
         $taskMediumPriority->project_id = $project->id;
+        $taskMediumPriority->skillset = $skillSet;
         $taskMediumPriority->save();
 
         $taskMediumPriority->submitted_for_qa = true;
@@ -425,14 +447,22 @@ class TaskUpdateXpTest extends TestCase
         $project->members = $members;
         $project->save();
 
+        $skillSet = [
+            'PHP',
+            'React',
+            'DevOps'
+        ];
+
         $taskHighPriorityWithoutOwner = $this->getNewTask();
         $taskHighPriorityWithoutOwner->project_id = $project->id;
         $taskHighPriorityWithoutOwner->priority = 'High';
+        $taskHighPriorityWithoutOwner->skillset = $skillSet;
         $taskHighPriorityWithoutOwner->save();
 
         $taskMediumPriorityWithoutOwner = $this->getNewTask();
         $taskMediumPriorityWithoutOwner->project_id = $project->id;
         $taskMediumPriorityWithoutOwner->priority = 'Medium';
+        $taskMediumPriorityWithoutOwner->skillset = $skillSet;
         $taskMediumPriorityWithoutOwner->save();
 
         // Assigned 30 minutes ago
@@ -445,6 +475,7 @@ class TaskUpdateXpTest extends TestCase
         $taskMediumPriority->complexity = 5;
         $taskMediumPriority->due_date = (new \DateTime())->modify('+1 day')->format('U');
         $taskMediumPriority->project_id = $project->id;
+        $taskMediumPriority->skillset = $skillSet;
         $taskMediumPriority->save();
 
         $taskMediumPriority->submitted_for_qa = true;
@@ -484,14 +515,22 @@ class TaskUpdateXpTest extends TestCase
         $project->members = $members;
         $project->save();
 
+        $skillSet = [
+            'PHP',
+            'React',
+            'DevOps'
+        ];
+
         $taskHighPriorityWithoutOwner = $this->getNewTask();
         $taskHighPriorityWithoutOwner->project_id = $project->id;
         $taskHighPriorityWithoutOwner->priority = 'High';
+        $taskHighPriorityWithoutOwner->skillset = $skillSet;
         $taskHighPriorityWithoutOwner->save();
 
         $taskMediumPriorityWithoutOwner = $this->getNewTask();
         $taskMediumPriorityWithoutOwner->project_id = $project->id;
         $taskMediumPriorityWithoutOwner->priority = 'Medium';
+        $taskMediumPriorityWithoutOwner->skillset = $skillSet;
         $taskMediumPriorityWithoutOwner->save();
 
         // Assigned 30 minutes ago
@@ -504,6 +543,7 @@ class TaskUpdateXpTest extends TestCase
         $taskHighPriority->complexity = 5;
         $taskHighPriority->due_date = (new \DateTime())->modify('+1 day')->format('U');
         $taskHighPriority->project_id = $project->id;
+        $taskHighPriority->skillset = $skillSet;
         $taskHighPriority->save();
 
         $taskHighPriority->submitted_for_qa = true;


### PR DESCRIPTION
PHP account profile skills on task claim against the xp coefficient

Apply priority coefficient only if there are no higher priority tasks for users skills, cover with unit tests.
I.e. if developer has just PHP skill, and highest priority task for PHP available is Medium, while there's React task available with High priority, award user with full xp coefficient (1) regardless.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58bfe0c93e5bbe3ced678bfb/tasks/58c2b9a83e5bbe05607cd0c4)

## Checklist
- [x] Tests covered

## Test notes
Create some tasks with different skills and priorities. Test task claiming or just view and check task priority coefficient.