### PR TITLE
Fixed due dates query, query only ready tasks

### DIFF
--- a/app/Console/Commands/NotifyProjectParticipantsAboutTaskDeadline.php
+++ b/app/Console/Commands/NotifyProjectParticipantsAboutTaskDeadline.php
@@ -40,12 +40,15 @@ class NotifyProjectParticipantsAboutTaskDeadline extends Command
     {
         GenericModel::setCollection('tasks');
 
+        $unixNow = (int) Carbon::now()->format('U');
         // Unix timestamp 7 days from now at the end of the day
         $unixSevenDaysFromNow = (int) Carbon::now()->addDays(7)->format('U')
             + (int)Carbon::now()->addDays(7)->secondsUntilEndOfDay();
 
         // Get all unfinished tasks with due_date within next 7 days
         $tasks = GenericModel::where('due_date', '<=', $unixSevenDaysFromNow)
+            ->where('due_date', '>=', $unixNow)
+            ->where('ready', '=', true)
             ->where('passed_qa', '=', false)
             ->get();
 


### PR DESCRIPTION
Tested, working. 

# Test notes

Create some tasks with different due_dates. Set some of them to be ready and some tasks not ready. Run command.