### PR TITLE
Cron job to notify project owners about tasks waiting for QA

### DIFF
--- a/app/Console/Commands/NotifyAdminsQaWaitingTasks.php
+++ b/app/Console/Commands/NotifyAdminsQaWaitingTasks.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\GenericModel;
+use App\Helpers\Slack;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Config;
+use App\Profile;
+
+/**
+ * Class NotifyAdminsQaWaitingTasks
+ * @package App\Console\Commands
+ */
+class NotifyAdminsQaWaitingTasks extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ping:admins:qa:waiting:tasks';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Cron job that will ping admins on slack about tasks that were submitted for QA yesterday';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $dateYesterday = Carbon::yesterday()->format('Y-m-d');
+        $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
+
+        // Get all tasks that are submitted for QA
+        GenericModel::setCollection('tasks');
+        $tasksInQa = GenericModel::where('submitted_for_qa', '=', true)
+            ->get();
+
+        // Get projects and project owners
+        $projects = [];
+        $projectOwners = [];
+        foreach ($tasksInQa as $task) {
+            if (!array_key_exists($task->project_id, $projects)) {
+                GenericModel::setCollection('projects');
+                $project = GenericModel::find($task->project_id);
+                if ($project) {
+                    $projects[$project->_id] = $project;
+                }
+            }
+        }
+        foreach ($projects as $project) {
+            $profile = Profile::find($project->acceptedBy);
+            if ($profile) {
+                $projectOwners[] = $profile;
+            }
+        }
+
+        /*Loop through project owners and tasks, check if there are tasks that are submitted for QA yesterday and
+        create message and send to project owners*/
+        foreach ($projectOwners as $projectOwner) {
+            if ($projectOwner->slack) {
+                $recipient = '@' . $projectOwner->slack;
+                $message = 'Hey, these tasks are *submitted for QA yesterday* and waiting for review:';
+
+                foreach ($tasksInQa as $task) {
+                    if ($projectOwner->_id === $projects[$task->project_id]->acceptedBy) {
+                        foreach ($task->task_history as $historyRecord) {
+                            if ($historyRecord['status'] === 'qa_ready'
+                                && Carbon::createFromTimestamp($historyRecord['timestamp'])->format('Y-m-d')
+                                === $dateYesterday
+                            ) {
+                                $message .= ' *'
+                                    . $task->title
+                                    . ' ('
+                                    . Carbon::createFromTimestamp($task->due_date)->format('Y-m-d')
+                                    . ')* '
+                                    . $webDomain
+                                    . 'projects/'
+                                    . $task->project_id
+                                    . '/sprints/'
+                                    . $task->sprint_id
+                                    . '/tasks/'
+                                    . $task->_id
+                                    . ' ';
+                            }
+                        }
+                    }
+                }
+                // Send message
+                Slack::sendMessage($recipient, $message, Slack::HIGH_PRIORITY);
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -25,6 +25,7 @@ class Kernel extends ConsoleKernel
         Commands\SlackSendMessages::class,
         Commands\UpdateTaskPriority::class,
         Commands\NotifyAdminsTaskPriority::class,
+        Commands\NotifyAdminsQaWaitingTasks::class
     ];
 
     /**
@@ -66,12 +67,16 @@ class Kernel extends ConsoleKernel
         // Check for messages to send every minute
         $schedule->command('slack:send-messages');
 
-        //Check task deadline and update priority
+        // Check task deadline and update priority
         $schedule->command('update:task:priority')
             ->dailyAt('07:00');
 
-        //Check task deadlines based on priority and ping admins
+        // Check task deadlines based on priority and ping admins
         $schedule->command('ping:admins:task:priority')
             ->dailyAt('07:00');
+
+        // Ping admins about tasks with Qa in progress
+        $schedule->command('ping:admins:qa:waiting:tasks')
+            ->twiceDaily(9, 14);
     }
 }


### PR DESCRIPTION
Implement slack notification for project owners for QA waiting tasks

cron 2 times a day - at 10 am and at 3 PM - ping POs about all tasks that were submitted for QA yesterday

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58da133f3e5bbe58fe45f184/tasks/58dd115c3e5bbe0e85134eaf)

## Test notes
Create some projects and set different project owners. Create some tasks on projects, claim them and set them to submitted_for_qa. Modify then timestamp of qa_ready on some tasks. Run cron job.