### PR TITLE
Change xp award and deduction

### DIFF
--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -51,7 +51,7 @@ class Task implements AdaptersInterface
 
         $this->task->estimate = (float) sprintf('%.2f', $this->task->estimatedHours);
         $this->task->estimatedHours = (float) $originalEstimate;
-        $this->task->xp = (float) sprintf('%.2f', $this->task->xp);
+        $this->task->xp = (float) sprintf('%.2f', $this->task->xp * 2); // Multiply basic xp by 2
         $this->task->payout = (float) sprintf('%.2f', $mappedValues['payout']);
 
         $taskStatus = $profilePerformance->perTask($this->task);

--- a/app/Adapters/Task.php
+++ b/app/Adapters/Task.php
@@ -51,7 +51,7 @@ class Task implements AdaptersInterface
 
         $this->task->estimate = (float) sprintf('%.2f', $this->task->estimatedHours);
         $this->task->estimatedHours = (float) $originalEstimate;
-        $this->task->xp = (float) sprintf('%.2f', $this->task->xp * 2); // Multiply basic xp by 2
+        $this->task->xp = (float) sprintf('%.2f', $this->task->xp);
         $this->task->payout = (float) sprintf('%.2f', $mappedValues['payout']);
 
         $taskStatus = $profilePerformance->perTask($this->task);

--- a/app/Listeners/TaskUpdateXP.php
+++ b/app/Listeners/TaskUpdateXP.php
@@ -71,10 +71,10 @@ class TaskUpdateXP
             $taskXp = (float) $mappedValues['xp'];
 
             if ($taskFinishedDate <= $taskDueDate) {
-                $xpDiff = $taskXp;
+                $xpDiff = $taskXp * 2; // Xp award - multiply basic xp by 2
                 $message = 'Task Delivered on time: ' . $taskLink;
             } else {
-                $xpDiff = -5;
+                $xpDiff = -($taskXp * 15); // Xp deduction - multiply basic xp by 15
                 $message = 'Late task delivery: ' . $taskLink;
             }
 

--- a/app/Listeners/TaskUpdateXP.php
+++ b/app/Listeners/TaskUpdateXP.php
@@ -69,12 +69,13 @@ class TaskUpdateXP
             $taskFinishedDate = Carbon::createFromFormat('U', $taskFinishedUnixTime)->format('Y-m-d');
             $taskDueDate = Carbon::createFromFormat('U', $taskDueDateUnixTime)->format('Y-m-d');
             $taskXp = (float) $mappedValues['xp'];
+            $taskXpDeduction = (float) $mappedValues['xpDeduction'];
 
             if ($taskFinishedDate <= $taskDueDate) {
-                $xpDiff = $taskXp * 2; // Xp award - multiply basic xp by 2
+                $xpDiff = $taskXp;
                 $message = 'Task Delivered on time: ' . $taskLink;
             } else {
-                $xpDiff = -($taskXp * 15); // Xp deduction - multiply basic xp by 15
+                $xpDiff = -($taskXpDeduction);
                 $message = 'Late task delivery: ' . $taskLink;
             }
 

--- a/tests/Listeners/TaskUpdateXpTest.php
+++ b/tests/Listeners/TaskUpdateXpTest.php
@@ -84,7 +84,7 @@ class TaskUpdateXpTest extends TestCase
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + $profileValues['xp'], $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -123,7 +123,7 @@ class TaskUpdateXpTest extends TestCase
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + $profileValues['xp'], $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -161,7 +161,7 @@ class TaskUpdateXpTest extends TestCase
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals($profileOldXp - ($profileValues['xp'] * 15), $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp - $profileValues['xpDeduction'], $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -215,7 +215,7 @@ class TaskUpdateXpTest extends TestCase
 
         // Task done in time so task owner(admin also) get's XP for task and for Qa
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2) + 0.25, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + $profileValues['xp'] + 0.25, $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -269,7 +269,7 @@ class TaskUpdateXpTest extends TestCase
 
         // Task owner get's XP for early delivery and xp is deducted because code not reviewed in time
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2) - 3, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + $profileValues['xp'] - 3, $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -331,7 +331,7 @@ class TaskUpdateXpTest extends TestCase
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + $profileValues['xp'], $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -403,7 +403,7 @@ class TaskUpdateXpTest extends TestCase
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + $profileValues['xp'], $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -470,7 +470,7 @@ class TaskUpdateXpTest extends TestCase
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + $profileValues['xp'], $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -542,7 +542,7 @@ class TaskUpdateXpTest extends TestCase
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + $profileValues['xp'], $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -614,7 +614,7 @@ class TaskUpdateXpTest extends TestCase
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + $profileValues['xp'], $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 

--- a/tests/Listeners/TaskUpdateXpTest.php
+++ b/tests/Listeners/TaskUpdateXpTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Listeners;
 
+use App\Services\ProfilePerformance;
 use Tests\TestCase;
 use Tests\Collections\ProjectRelated;
 use App\Profile;
@@ -74,12 +75,16 @@ class TaskUpdateXpTest extends TestCase
         $task->save();
         $task->passed_qa = true;
 
+        $pp = new ProfilePerformance();
+        $profileValues = $pp->getTaskValuesForProfile($this->profile, $task);
+        $profileOldXp = $this->profile->xp;
+
         $event = new ModelUpdate($task);
         $listener = new TaskUpdateXP($task);
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals(200.2025, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -109,12 +114,16 @@ class TaskUpdateXpTest extends TestCase
         $task->save();
         $task->passed_qa = true;
 
+        $pp = new ProfilePerformance();
+        $profileValues = $pp->getTaskValuesForProfile($this->profile, $task);
+        $profileOldXp = $this->profile->xp;
+
         $event = new ModelUpdate($task);
         $listener = new TaskUpdateXP($task);
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals(200.2025, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -143,15 +152,22 @@ class TaskUpdateXpTest extends TestCase
         $task->save();
         $task->passed_qa = true;
 
+        $pp = new ProfilePerformance();
+        $profileValues = $pp->getTaskValuesForProfile($this->profile, $task);
+        $profileOldXp = $this->profile->xp;
+
         $event = new ModelUpdate($task);
         $listener = new TaskUpdateXP($task);
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals(195, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp - ($profileValues['xp'] * 15), $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
+    /**
+     * Test update XP for delivered task in time + QA (project owner)
+     */
     public function testTaskUpdateXpProjectOwnerReviewInTime()
     {
         $project = $this->getNewProject();
@@ -185,21 +201,27 @@ class TaskUpdateXpTest extends TestCase
         $worked[$task->owner]['workTrackTimestamp'] =
             (int) (new \DateTime())->sub(new \DateInterval('PT' . $passedQaAgo . 'M'))->format('U');
 
-
         $task->work = $worked;
         $task->save();
         $task->passed_qa = true;
+
+        $pp = new ProfilePerformance();
+        $profileValues = $pp->getTaskValuesForProfile($this->profile, $task);
+        $profileOldXp = $this->profile->xp;
 
         $event = new ModelUpdate($task);
         $listener = new TaskUpdateXP($task);
         $out = $listener->handle($event);
 
-        // Task done in time so task owner(admin also) get's double XP
+        // Task done in time so task owner(admin also) get's XP for task and for Qa
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals(200.4525, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2) + 0.25, $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
+    /**
+     * Check update XP for late review QA - xp deduction
+     */
     public function testTaskUpdateXpProjectOwnerReviewLate()
     {
         $project = $this->getNewProject();
@@ -237,13 +259,17 @@ class TaskUpdateXpTest extends TestCase
         $task->save();
         $task->passed_qa = true;
 
+        $pp = new ProfilePerformance();
+        $profileValues = $pp->getTaskValuesForProfile($this->profile, $task);
+        $profileOldXp = $this->profile->xp;
+
         $event = new ModelUpdate($task);
         $listener = new TaskUpdateXP($task);
         $out = $listener->handle($event);
 
-        // Task owner get's XP for early delivery and xp is deducted because code note reviewed in time
+        // Task owner get's XP for early delivery and xp is deducted because code not reviewed in time
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals(197.2025, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2) - 3, $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -296,12 +322,16 @@ class TaskUpdateXpTest extends TestCase
         $taskLowPriority->save();
         $taskLowPriority->passed_qa = true;
 
+        $pp = new ProfilePerformance();
+        $profileValues = $pp->getTaskValuesForProfile($this->profile, $taskLowPriority);
+        $profileOldXp = $this->profile->xp;
+
         $event = new ModelUpdate($taskLowPriority);
         $listener = new TaskUpdateXP($taskLowPriority);
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals(200.2025, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -364,12 +394,16 @@ class TaskUpdateXpTest extends TestCase
         $taskLowPriority->save();
         $taskLowPriority->passed_qa = true;
 
+        $pp = new ProfilePerformance();
+        $profileValues = $pp->getTaskValuesForProfile($this->profile, $taskLowPriority);
+        $profileOldXp = $this->profile->xp;
+
         $event = new ModelUpdate($taskLowPriority);
         $listener = new TaskUpdateXP($taskLowPriority);
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals(200.10125, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -427,12 +461,16 @@ class TaskUpdateXpTest extends TestCase
         $taskMediumPriority->save();
         $taskMediumPriority->passed_qa = true;
 
+        $pp = new ProfilePerformance();
+        $profileValues = $pp->getTaskValuesForProfile($this->profile, $taskMediumPriority);
+        $profileOldXp = $this->profile->xp;
+
         $event = new ModelUpdate($taskMediumPriority);
         $listener = new TaskUpdateXP($taskMediumPriority);
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals(200.2025, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -495,12 +533,16 @@ class TaskUpdateXpTest extends TestCase
         $taskMediumPriority->save();
         $taskMediumPriority->passed_qa = true;
 
+        $pp = new ProfilePerformance();
+        $profileValues = $pp->getTaskValuesForProfile($this->profile, $taskMediumPriority);
+        $profileOldXp = $this->profile->xp;
+
         $event = new ModelUpdate($taskMediumPriority);
         $listener = new TaskUpdateXP($taskMediumPriority);
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals(200.162, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -563,12 +605,16 @@ class TaskUpdateXpTest extends TestCase
         $taskHighPriority->save();
         $taskHighPriority->passed_qa = true;
 
+        $pp = new ProfilePerformance();
+        $profileValues = $pp->getTaskValuesForProfile($this->profile, $taskHighPriority);
+        $profileOldXp = $this->profile->xp;
+
         $event = new ModelUpdate($taskHighPriority);
         $listener = new TaskUpdateXP($taskHighPriority);
         $out = $listener->handle($event);
 
         $checkXpProfile = Profile::find($this->profile->id);
-        $this->assertEquals(200.2025, $checkXpProfile->xp);
+        $this->assertEquals($profileOldXp + ($profileValues['xp'] * 2), $checkXpProfile->xp);
         $this->assertEquals(true, $out);
     }
 
@@ -587,8 +633,7 @@ class TaskUpdateXpTest extends TestCase
         $out = $listener->handle($event);
 
         $this->assertEquals(false, $out);
-
-
+        
         // Let's make some update
         $task->priority = 'High';
         $task->title = 'Test';


### PR DESCRIPTION
Update XP calculation

Multiply current coefficient by 2 for done in time tasks,
Take same coefficient (original) and multiply by 15 for deduction for tasks that are passed due.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58da133f3e5bbe58fe45f184/tasks/58d506843e5bbe43e052fa4d)

## Checklist
- [x] Tests covered

## Test notes
Create some projects, sprints, and tasks. Assign some task with test user (not admin). Check xp on view with admin user, login with test user check xp on task view. Finish task on time and check xp history on profile. Repeat process with another task but finish him after due_date to check xp deduction. Unit tests updated.