### PR TITLE
Deduct at least 1 xp for late task delivery

### DIFF
--- a/app/Listeners/TaskUpdateXP.php
+++ b/app/Listeners/TaskUpdateXP.php
@@ -75,7 +75,7 @@ class TaskUpdateXP
                 $xpDiff = $taskXp;
                 $message = 'Task Delivered on time: ' . $taskLink;
             } else {
-                $xpDiff = -($taskXpDeduction);
+                $xpDiff = $taskXpDeduction < 1 ? -1 : -($taskXpDeduction); // Deduct at least 1 xp
                 $message = 'Late task delivery: ' . $taskLink;
             }
 


### PR DESCRIPTION
Late task delivery should deduct at least 1 XP

In case calculated deduction is less than 1 XP, make it 1 XP

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58e20e893e5bbe5a3423ddf2/tasks/58e4b0983e5bbe089d7ba1ee)

## Checklist
-[x] Tests covered

Create some task and set task estimatedHours + profileXP so calculated XP for task deduction is less then 1 xp. Finish task late and check profile XP.