### PR TITLE
Ping admins and project owners about late due_date tasks and QA ready tasks

### DIFF
--- a/app/Console/Commands/NotifyAdminsAndPoAboutLateAndQaTasks.php
+++ b/app/Console/Commands/NotifyAdminsAndPoAboutLateAndQaTasks.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\GenericModel;
+use App\Profile;
+use Illuminate\Console\Command;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Config;
+use App\Helpers\Slack;
+
+class NotifyAdminsAndPoAboutLateAndQaTasks extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ping:admins:late-and-qa-tasks';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Cron: job that will send slack message to admin / PO with all late tasks and QA 
+    waiting tasks';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $unixNow = (int)Carbon::now()->format('U');
+        $webDomain = Config::get('sharedSettings.internalConfiguration.webDomain');
+        $sendMessage = false;
+
+        GenericModel::setCollection('tasks');
+        // Get all late unfinished tasks (lower due_date then today)
+        $lateTasks = GenericModel::where('due_date', '<=', $unixNow)
+            ->where('ready', '=', true)
+            ->where('passed_qa', '=', false)
+            ->get();
+
+        // Get all tasks that are submitted_for_qa
+        $qaTasks = GenericModel::where('submitted_for_qa', '=', true)
+            ->get();
+
+        // Merge tasks
+        $tasks = $lateTasks->merge($qaTasks);
+
+        // Get all tasks projects so we can check project owners
+        $projects = [];
+        GenericModel::setCollection('projects');
+        foreach ($tasks as $task) {
+            if (!key_exists($task->project_id, $projects)) {
+                $project = GenericModel::find($task->project_id);
+                if ($project) {
+                    $projects[$project->_id] = $project;
+                }
+            }
+        }
+
+        // Get all admins
+        $admins = Profile::where('admin', '=', true)
+            ->where('active', '=', true)
+            ->get();
+
+        // Get all project owners
+        $projectOwners = [];
+        foreach ($projects as $singleProject) {
+            $po = Profile::where('_id', '=', $singleProject->acceptedBy)
+                ->where('active', '=', true)
+                ->first();
+            if ($po) {
+                $projectOwners[] = $po;
+            }
+        }
+
+        // Merge admins and project owners
+        $adminsAndPo = $admins->merge($projectOwners);
+
+        // Loop through tasks, generate message and notify admins and project owners on slack about late tasks
+        foreach ($adminsAndPo as $profileToNotify) {
+            if ($profileToNotify->slack) {
+                $recipient = '@' . $profileToNotify->slack;
+                $message = 'Hey, these tasks are *late or waiting for QA*: ';
+                foreach ($tasks as $taskToNotify) {
+                    if ($profileToNotify->_id !== $projects[$taskToNotify->project_id]->acceptedBy
+                        && !$profileToNotify->admin
+                    ) {
+                        continue;
+                    }
+                    $message .= ' *'
+                        . $taskToNotify->title
+                        . ' ('
+                        . Carbon::createFromTimestamp($taskToNotify->due_date)->format('Y-m-d')
+                        . ')* '
+                        . ($taskToNotify->submitted_for_qa === true ? '*QA_READY*' : '*DUE_DATE_PASSED*')
+                        . ' on project *'
+                        . $projects[$taskToNotify->project_id]->name
+                        . '* '
+                        . $webDomain
+                        . 'projects/'
+                        . $taskToNotify->project_id
+                        . '/sprints/'
+                        . $taskToNotify->sprint_id
+                        . '/tasks/'
+                        . $taskToNotify->_id
+                        . ' ';
+                    if (!$sendMessage) {
+                        $sendMessage = true;
+                    }
+                }
+                // Send message
+                if ($sendMessage) {
+                    Slack::sendMessage($recipient, $message, Slack::HIGH_PRIORITY);
+                    $sendMessage = false;
+                }
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Console;
 
 use App\Helpers\WorkDays;
+use Aws\Command;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 use Carbon\Carbon;
@@ -25,7 +26,8 @@ class Kernel extends ConsoleKernel
         Commands\SlackSendMessages::class,
         Commands\UpdateTaskPriority::class,
         Commands\NotifyAdminsTaskPriority::class,
-        Commands\NotifyAdminsQaWaitingTasks::class
+        Commands\NotifyAdminsQaWaitingTasks::class,
+        Commands\NotifyAdminsAndPoAboutLateAndQaTasks::class,
     ];
 
     /**
@@ -78,5 +80,9 @@ class Kernel extends ConsoleKernel
         // Ping admins about tasks with Qa in progress
         $schedule->command('ping:admins:qa:waiting:tasks')
             ->twiceDaily(9, 14);
+
+        // Ping admins and project owners about late tasks and Qa waiting tasks
+        $schedule->command('ping:admins:late-and-qa-tasks')
+            ->dailyAt('08:00');
     }
 }


### PR DESCRIPTION
Cron: job that will send slack message to admin / PO with all late tasks and QA waiting tasks

Single message with links to all tasks whose due date has passed. Once a day with high priority at 9 AM.

[Task link](http://the-shop.io:3000/projects/586016083e5bbe768349a4b0/sprints/58f1e4573e5bbe26b221afe5/tasks/58fda1573e5bbe64e6443af7)

## Test notes
Create few projects with sprints and tasks. Set some tasks due_date lower than today, set different project owners to projects and set some admins to profiles. Some tasks put on qa_ready also. Then run php artisan ping:admin:late-and-qa-tasks and check database collection slackMessages for result.