### PR TITLE
Migration to create accounts for starapi profiles

### DIFF
--- a/database/migrations/2017_05_15_084908_accounts_database_migration.php
+++ b/database/migrations/2017_05_15_084908_accounts_database_migration.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace {
+
+    use App\GenericModel;
+    use Illuminate\Database\Migrations\Migration;
+
+    class AccountsDatabaseMigration extends Migration
+    {
+        /**
+         * Run the migrations.
+         *
+         * @return void
+         */
+        public function up()
+        {
+            $profiles = GenericModel::whereTo('profiles')->all();
+
+            $applications = ['starapi'];
+
+            foreach ($profiles as $profile) {
+                $account = new GenericModel([
+                    'name' => $profile->name,
+                    'email' => $profile->email,
+                    'password' => $profile->password,
+                    'applications' => $applications
+                ]);
+                $account->_id = $profile->_id;
+                $account->saveModel('accounts', 'accounts');
+            }
+        }
+
+        /**
+         * Reverse the migrations.
+         *
+         * @return void
+         */
+        public function down()
+        {
+            //
+        }
+    }
+}


### PR DESCRIPTION
Migration to create accounts in accounts database for existing starapi profiles. There is no applications database for now, should be refactored later on. Middleware checks on account if there is application in applications array, checks if database exists and checks if account has got profile related to that account on specific application. 